### PR TITLE
feat: Support Text Replacer and File Macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,14 @@ Pure black (`#000000`) Material 3 interface designed for OLED screens — saves 
 ### 🤖 Powered by Gemini & Custom Providers
 Ships with Google's Gemini API (`gemini-2.5-flash-lite`, `gemini-3-flash-preview`, or `gemini-3.1-flash-lite-preview`). Or connect **any OpenAI-compatible endpoint** — use your own provider, model, and base URL.
 
-### 🎨 Custom Commands
-Create your own trigger → prompt pairs. Define `?poem` to turn text into poetry, `?eli5` to simplify for a five-year-old, or anything you can imagine.
+### 🎨 Action Types
+Create your own commands mapped to three action types: **AI Action** (rewrite text dynamically), **Content Replacer** (paste static text instantly offline), or **File Share** (pop open a file ready to send).
 
 ### 🔒 Encrypted Key Storage
 API keys are encrypted with **AES-256-GCM** using the Android Keystore. Your keys never leave your device unencrypted.
 
 ### 🛡️ Privacy-First
-No analytics. No telemetry. No intermediary servers. Text is sent directly to the configured provider's API and only when a trigger is detected.
+No analytics. No telemetry. No intermediary servers. Text is sent directly to the configured provider's API and only when a trigger is detected. Text Replacer and File Share commands run entirely offline.
 
 </td>
 </tr>
@@ -255,14 +255,23 @@ flowchart TD
 
 ## 🎨 Custom Commands
 
-Go beyond the built-ins — create your own trigger → prompt pairs in the **Commands** tab.
+Go beyond the built-ins — create your own commands in the **Commands** tab using a dedicated prefix separating AI from offline actions.
+
+### Action Types
+
+When adding a new custom command, tap the top segmented toggle to choose your desired behavior:
+
+1. **AI Action**: Set a prompt (e.g. `Summarize this text in one sentence.`). SwiftSlate extracts your typed text and sends it to your provider with this instruction.
+2. **Content Replacer (Snippets)**: Act as a text expander. Map a trigger (e.g., `/email`) to output static text instantly (`myemail@example.com`). Runs completely offline—zero delay.
+3. **File Share (Macro)**: Map a trigger (e.g., `/resume`) to securely stash a PDF or image path. When triggered, your text clears and Android's native share sheet pops up with the file pre-attached, ready to send anywhere.
 
 ### How to Create One
 
 1. Open the **Commands** screen
-2. Enter a **Trigger** (e.g., `?poem`)
-3. Enter a **Prompt** — the instruction sent to the AI
-4. Tap **"Add Command"**
+2. Select your action type toggle: **AI Action**, **Content Replacer**, or **File Share**.
+3. Enter a **Trigger** (e.g., `?poem` or `/email`)
+4. Enter your **Instruction/Replacement text/File URL**
+5. Tap **"Add Command"**
 
 ### Example Ideas
 

--- a/app/src/main/java/com/musheer360/swiftslate/manager/CommandManager.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/manager/CommandManager.kt
@@ -11,8 +11,10 @@ class CommandManager(context: Context) {
     private val settingsPrefs: SharedPreferences = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
 
     companion object {
-        const val DEFAULT_PREFIX = "?"
+        const val DEFAULT_PREFIX = "!"
         const val PREF_TRIGGER_PREFIX = "trigger_prefix"
+        const val DEFAULT_REPLACER_PREFIX = "/"
+        const val PREF_REPLACER_PREFIX = "replacer_prefix"
     }
 
     // Built-in command names (without prefix) and their prompts
@@ -36,25 +38,57 @@ class CommandManager(context: Context) {
         if (newPrefix.length != 1 || newPrefix[0].isLetterOrDigit() || newPrefix[0].isWhitespace()) return false
         val oldPrefix = getTriggerPrefix()
         if (oldPrefix == newPrefix) return true
-        // Write prefix FIRST (synchronous) so built-ins work immediately if process dies mid-migration
+        if (newPrefix == getReplacerPrefix()) return false // Prevent collision
+        
         settingsPrefs.edit().putString(PREF_TRIGGER_PREFIX, newPrefix).commit()
-        // Migrate custom command triggers
+        
+        migratePrefix(oldPrefix, newPrefix, com.musheer360.swiftslate.model.CommandType.AI)
+        return true
+    }
+
+    fun getReplacerPrefix(): String {
+        return settingsPrefs.getString(PREF_REPLACER_PREFIX, DEFAULT_REPLACER_PREFIX) ?: DEFAULT_REPLACER_PREFIX
+    }
+
+    fun setReplacerPrefix(newPrefix: String): Boolean {
+        if (newPrefix.length != 1 || newPrefix[0].isLetterOrDigit() || newPrefix[0].isWhitespace()) return false
+        val oldPrefix = getReplacerPrefix()
+        if (oldPrefix == newPrefix) return true
+        if (newPrefix == getTriggerPrefix()) return false // Prevent collision
+        
+        settingsPrefs.edit().putString(PREF_REPLACER_PREFIX, newPrefix).commit()
+        
+        migratePrefix(oldPrefix, newPrefix, null) // Migrate all replacer types
+        return true
+    }
+
+    private fun migratePrefix(oldPrefix: String, newPrefix: String, filterType: com.musheer360.swiftslate.model.CommandType?) {
         val customStr = prefs.getString("custom_commands", "[]") ?: "[]"
         val arr = JSONArray(customStr)
         val newArr = JSONArray()
         for (i in 0 until arr.length()) {
             val obj = arr.getJSONObject(i)
+            val typeStr = obj.optString("type", com.musheer360.swiftslate.model.CommandType.AI.name)
+            val type = try { com.musheer360.swiftslate.model.CommandType.valueOf(typeStr) } catch (e: Exception) { com.musheer360.swiftslate.model.CommandType.AI }
+            
+            val shouldMigrate = if (filterType == com.musheer360.swiftslate.model.CommandType.AI) {
+                type == com.musheer360.swiftslate.model.CommandType.AI
+            } else {
+                type == com.musheer360.swiftslate.model.CommandType.TEXT_REPLACER || type == com.musheer360.swiftslate.model.CommandType.FILE_SHARE
+            }
+
             val oldTrigger = obj.getString("trigger")
-            val migrated = if (oldTrigger.startsWith(oldPrefix)) {
+            val migrated = if (shouldMigrate && oldTrigger.startsWith(oldPrefix)) {
                 newPrefix + oldTrigger.removePrefix(oldPrefix)
             } else oldTrigger
+            
             val newObj = JSONObject()
             newObj.put("trigger", migrated)
             newObj.put("prompt", obj.getString("prompt"))
+            newObj.put("type", type.name)
             newArr.put(newObj)
         }
         prefs.edit().putString("custom_commands", newArr.toString()).apply()
-        return true
     }
 
     private fun getBuiltInCommands(): List<Command> {
@@ -68,7 +102,9 @@ class CommandManager(context: Context) {
         val customCommands = mutableListOf<Command>()
         for (i in 0 until arr.length()) {
             val obj = arr.getJSONObject(i)
-            customCommands.add(Command(obj.getString("trigger"), obj.getString("prompt"), false))
+            val typeStr = obj.optString("type", com.musheer360.swiftslate.model.CommandType.AI.name)
+            val type = try { com.musheer360.swiftslate.model.CommandType.valueOf(typeStr) } catch (e: Exception) { com.musheer360.swiftslate.model.CommandType.AI }
+            customCommands.add(Command(obj.getString("trigger"), obj.getString("prompt"), false, type))
         }
         return getBuiltInCommands() + customCommands
     }
@@ -79,6 +115,7 @@ class CommandManager(context: Context) {
         val newObj = JSONObject()
         newObj.put("trigger", command.trigger)
         newObj.put("prompt", command.prompt)
+        newObj.put("type", command.type.name)
         arr.put(newObj)
         prefs.edit().putString("custom_commands", arr.toString()).apply()
     }

--- a/app/src/main/java/com/musheer360/swiftslate/model/Command.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/model/Command.kt
@@ -1,7 +1,12 @@
 package com.musheer360.swiftslate.model
 
+enum class CommandType {
+    AI, TEXT_REPLACER, FILE_SHARE
+}
+
 data class Command(
     val trigger: String,
     val prompt: String,
-    val isBuiltIn: Boolean = false
+    val isBuiltIn: Boolean = false,
+    val type: CommandType = CommandType.AI
 )

--- a/app/src/main/java/com/musheer360/swiftslate/service/AssistantService.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/service/AssistantService.kt
@@ -125,10 +125,12 @@ class AssistantService : AccessibilityService() {
 
         val command = commandManager.findCommand(text) ?: return
 
-        val cleanText = text.substring(0, text.length - command.trigger.length).trim()
+        val precedingTextRaw = text.substring(0, text.length - command.trigger.length)
+        val cleanText = precedingTextRaw.trim()
+
+        if (source.isPassword) { return }
 
         if (command.trigger.endsWith("undo") && command.isBuiltIn) {
-            if (source.isPassword) { return }
             isProcessing = true
             processingStartedAt = System.currentTimeMillis()
             currentJob?.cancel()
@@ -136,12 +138,54 @@ class AssistantService : AccessibilityService() {
             return
         }
 
-        if (cleanText.isEmpty() || source.isPassword) { return }
+        when (command.type) {
+            com.musheer360.swiftslate.model.CommandType.AI -> {
+                if (cleanText.isEmpty()) return
+                isProcessing = true
+                processingStartedAt = System.currentTimeMillis()
+                currentJob?.cancel()
+                processCommand(source, cleanText, command)
+            }
+            com.musheer360.swiftslate.model.CommandType.TEXT_REPLACER -> {
+                handleTextReplacer(source, precedingTextRaw, command.prompt)
+            }
+            com.musheer360.swiftslate.model.CommandType.FILE_SHARE -> {
+                handleFileShare(source, precedingTextRaw, command.prompt)
+            }
+        }
+    }
 
-        isProcessing = true
-        processingStartedAt = System.currentTimeMillis()
-        currentJob?.cancel()
-        processCommand(source, cleanText, command)
+    private fun handleTextReplacer(source: AccessibilityNodeInfo, precedingText: String, replacementText: String) {
+        serviceScope.launch(Dispatchers.Main) {
+            val newText = precedingText + replacementText
+            replaceText(source, newText)
+            performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+        }
+    }
+
+    private fun handleFileShare(source: AccessibilityNodeInfo, precedingText: String, fileUriStr: String) {
+        serviceScope.launch(Dispatchers.Main) {
+            try {
+                replaceText(source, precedingText)
+                
+                val uri = android.net.Uri.parse(fileUriStr)
+                val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
+                    type = "*/*"
+                    putExtra(android.content.Intent.EXTRA_STREAM, uri)
+                    addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                
+                val chooser = android.content.Intent.createChooser(intent, "Share File").apply {
+                    addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                startActivity(chooser)
+                performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+            } catch (e: Exception) {
+                showToast("Could not share file: ${e.message}")
+                performHapticFeedback(HapticFeedbackConstants.REJECT)
+            }
+        }
     }
 
     private fun processCommand(source: AccessibilityNodeInfo, text: String, command: Command) {

--- a/app/src/main/java/com/musheer360/swiftslate/ui/CommandsScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/CommandsScreen.kt
@@ -1,5 +1,7 @@
 package com.musheer360.swiftslate.ui
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -20,9 +22,26 @@ import androidx.compose.ui.unit.sp
 import com.musheer360.swiftslate.R
 import com.musheer360.swiftslate.manager.CommandManager
 import com.musheer360.swiftslate.model.Command
+import com.musheer360.swiftslate.model.CommandType
 import com.musheer360.swiftslate.ui.components.ScreenTitle
 import com.musheer360.swiftslate.ui.components.SlateCard
 
+fun checkFileExists(context: android.content.Context, pathOrUri: String): Boolean {
+    if (pathOrUri.isBlank()) return false
+    try {
+        val uri = android.net.Uri.parse(pathOrUri)
+        if (uri.scheme == "content" || uri.scheme == "android.resource") {
+            context.contentResolver.openFileDescriptor(uri, "r")?.use {}
+            return true
+        }
+        val file = java.io.File(pathOrUri.removePrefix("file://"))
+        return file.exists()
+    } catch (e: Exception) {
+        return false
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CommandsScreen() {
     val context = LocalContext.current
@@ -32,9 +51,30 @@ fun CommandsScreen() {
     var trigger by remember { mutableStateOf("") }
     var prompt by remember { mutableStateOf("") }
     var errorMessage by remember { mutableStateOf<String?>(null) }
-    val prefix = commandManager.getTriggerPrefix()
-    val errorPrefixMsg = stringResource(R.string.commands_error_prefix, prefix)
+    
+    var selectedType by remember { mutableStateOf(CommandType.AI) }
+
+    val aiPrefix = commandManager.getTriggerPrefix()
+    val replacerPrefix = commandManager.getReplacerPrefix()
+    val activePrefix = if (selectedType == CommandType.AI) aiPrefix else replacerPrefix
+
+    val errorPrefixMsg = stringResource(R.string.commands_error_prefix, activePrefix)
     val errorDuplicateMsg = stringResource(R.string.commands_error_duplicate)
+
+    val filePickerLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri: android.net.Uri? ->
+        uri?.let {
+            try {
+                context.contentResolver.takePersistableUriPermission(
+                    it,
+                    android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
+                )
+            } catch (e: Exception) {}
+            prompt = it.toString()
+            errorMessage = null
+        }
+    }
 
     Column(
         modifier = Modifier
@@ -51,14 +91,33 @@ fun CommandsScreen() {
                 fontSize = 18.sp,
                 color = MaterialTheme.colorScheme.onSurface
             )
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(16.dp))
+            
+            SingleChoiceSegmentedButtonRow(
+                modifier = Modifier.fillMaxWidth().padding(bottom = 12.dp)
+            ) {
+                listOf("AI Action", "Content Replacer", "File Share").forEachIndexed { index, title ->
+                    SegmentedButton(
+                        selected = selectedType.ordinal == index,
+                        onClick = { 
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            selectedType = CommandType.entries[index]
+                            errorMessage = null
+                        },
+                        shape = SegmentedButtonDefaults.itemShape(index = index, count = 3)
+                    ) {
+                        Text(title, fontSize = 12.sp)
+                    }
+                }
+            }
+
             OutlinedTextField(
                 value = trigger,
                 onValueChange = {
                     trigger = it
                     errorMessage = null
                 },
-                label = { Text(stringResource(R.string.commands_trigger_label, prefix)) },
+                label = { Text(stringResource(R.string.commands_trigger_label, activePrefix)) },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
                 colors = OutlinedTextFieldDefaults.colors(
@@ -67,16 +126,49 @@ fun CommandsScreen() {
                 )
             )
             Spacer(modifier = Modifier.height(8.dp))
-            OutlinedTextField(
-                value = prompt,
-                onValueChange = { prompt = it },
-                label = { Text(stringResource(R.string.commands_prompt_label)) },
-                modifier = Modifier.fillMaxWidth().height(100.dp),
-                colors = OutlinedTextFieldDefaults.colors(
-                    focusedBorderColor = MaterialTheme.colorScheme.primary,
-                    unfocusedBorderColor = MaterialTheme.colorScheme.outline
+            
+            val promptLabel = when (selectedType) {
+                CommandType.AI -> stringResource(R.string.commands_prompt_label)
+                CommandType.TEXT_REPLACER -> "Replacement Text (e.g., Let's connect!)"
+                CommandType.FILE_SHARE -> "File Path or URI"
+            }
+
+            if (selectedType == CommandType.FILE_SHARE) {
+                Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    OutlinedTextField(
+                        value = prompt,
+                        onValueChange = { 
+                            prompt = it 
+                            errorMessage = null
+                        },
+                        label = { Text(promptLabel) },
+                        modifier = Modifier.weight(1f),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = MaterialTheme.colorScheme.primary,
+                            unfocusedBorderColor = MaterialTheme.colorScheme.outline
+                        )
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Button(
+                        onClick = { filePickerLauncher.launch(arrayOf("*/*")) },
+                        modifier = Modifier.padding(top = 8.dp)
+                    ) {
+                        Text("Browse")
+                    }
+                }
+            } else {
+                OutlinedTextField(
+                    value = prompt,
+                    onValueChange = { prompt = it },
+                    label = { Text(promptLabel) },
+                    modifier = Modifier.fillMaxWidth().height(100.dp),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.outline
+                    )
                 )
-            )
+            }
+
             errorMessage?.let { msg ->
                 Text(
                     text = msg,
@@ -94,7 +186,7 @@ fun CommandsScreen() {
                     onClick = {
                         val trimmedTrigger = trigger.trim()
                         if (trimmedTrigger.isNotBlank() && prompt.isNotBlank()) {
-                            if (!trimmedTrigger.startsWith(prefix)) {
+                            if (!trimmedTrigger.startsWith(activePrefix)) {
                                 errorMessage = errorPrefixMsg
                                 return@Button
                             }
@@ -102,8 +194,13 @@ fun CommandsScreen() {
                                 errorMessage = errorDuplicateMsg
                                 return@Button
                             }
+                            if (selectedType == CommandType.FILE_SHARE && !checkFileExists(context, prompt.trim())) {
+                                errorMessage = "File could not be found or read. Please check the path."
+                                return@Button
+                            }
+                            
                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                            val newCommand = Command(trimmedTrigger, prompt.trim(), false)
+                            val newCommand = Command(trimmedTrigger, prompt.trim(), false, selectedType)
                             commandManager.addCustomCommand(newCommand)
                             commands = commandManager.getCommands()
                             trigger = ""
@@ -139,8 +236,27 @@ fun CommandsScreen() {
                                 color = MaterialTheme.colorScheme.primary
                             )
                             Spacer(modifier = Modifier.height(4.dp))
+                            
+                            val typeLabel = when (cmd.type) {
+                                CommandType.AI -> "AI Action"
+                                CommandType.TEXT_REPLACER -> "Content Replacer"
+                                CommandType.FILE_SHARE -> "File Share"
+                            }
                             Text(
-                                text = cmd.prompt,
+                                text = "[$typeLabel]",
+                                fontSize = 12.sp,
+                                color = MaterialTheme.colorScheme.secondary,
+                                fontWeight = FontWeight.Medium
+                            )
+                            Spacer(modifier = Modifier.height(2.dp))
+                            
+                            Text(
+                                text = if (cmd.type == CommandType.FILE_SHARE) {
+                                    val decoded = try { java.net.URLDecoder.decode(cmd.prompt, "UTF-8") } catch(e: Exception) { cmd.prompt }
+                                    decoded.takeLast(40).let { if (decoded.length > 40) "...$it" else it }
+                                } else {
+                                    cmd.prompt
+                                },
                                 fontSize = 14.sp,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )

--- a/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
@@ -263,5 +263,62 @@ fun SettingsScreen() {
                 )
             }
         }
+        
+        Spacer(modifier = Modifier.height(12.dp))
+
+        var replacerPrefix by remember { mutableStateOf(commandManager.getReplacerPrefix()) }
+        var replacerPrefixError by remember { mutableStateOf<String?>(null) }
+
+        SlateCard {
+            Text(
+                text = "Text/File Replacer Prefix",
+                fontWeight = FontWeight.Bold,
+                fontSize = 18.sp,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Symbol used before static snippet and file sharing commands (e.g., /email).",
+                fontSize = 13.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            OutlinedTextField(
+                value = replacerPrefix,
+                onValueChange = { input ->
+                    val filtered = input.take(1)
+                    replacerPrefix = filtered
+                    replacerPrefixError = when {
+                        filtered.length != 1 -> prefixErrorLength
+                        filtered[0].isWhitespace() -> prefixErrorWhitespace
+                        filtered[0].isLetterOrDigit() -> prefixErrorAlphanumeric
+                        filtered == triggerPrefix -> "Cannot be the same as AI trigger prefix"
+                        else -> {
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            if (!commandManager.setReplacerPrefix(filtered)) {
+                                "Failed to set prefix"
+                            } else {
+                                null
+                            }
+                        }
+                    }
+                },
+                singleLine = true,
+                modifier = Modifier.width(80.dp),
+                isError = replacerPrefixError != null,
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = MaterialTheme.colorScheme.primary,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.outline
+                )
+            )
+            replacerPrefixError?.let { msg ->
+                Text(
+                    text = msg,
+                    color = MaterialTheme.colorScheme.error,
+                    fontSize = 13.sp,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+            }
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,7 +47,7 @@
     <string name="settings_model_desc">Model identifier from your provider</string>
     <string name="settings_endpoint_placeholder">https://api.example.com/v1</string>
     <string name="settings_model_placeholder">gpt-4o, claude-3-haiku, etc.</string>
-    <string name="settings_trigger_prefix_title">Trigger Prefix</string>
+    <string name="settings_trigger_prefix_title">Ai Trigger Prefix</string>
     <string name="settings_trigger_prefix_desc">Symbol used before command names (e.g., %1$sfix). Must be a single non-alphanumeric character.</string>
     <string name="settings_prefix_error_length">Must be exactly 1 character</string>
     <string name="settings_prefix_error_whitespace">Cannot be whitespace</string>


### PR DESCRIPTION
### Description
This PR introduces **Action Types**, significantly expanding SwiftSlate's capabilities beyond AI generation. It adds support for offline **Text Replacer Snippets** and **File Share Macros**, effectively turning the app into a system-wide text expander and file sharing shortcut tool. 

### Key Features
* **New Action Types (Commands Screen)**:
  * Implemented a Material 3 Segmented Toggle letting users choose between **AI Action**, **Content Replacer**, or **File Share** when creating custom commands.
  * Dynamically updates the form fields based on the selected type.
* **Content Replacer (Snippets)**:
  * Allows users to map triggers (e.g., `/email`) to static text snippets that are pasted instantly and offline.
* **Instant File Sharing Macros**:
  * Users can now attach local files (documents, images, videos) to a command. Typing the trigger instantly strips the command text and pops open the Android Native Share Sheet pre-populated with the file, ready to beam to the active application.
  * Includes a built-in file browser using `ActivityResultContracts.OpenDocument`.
  * Persists URI permissions gracefully so files are still accessible after a reboot.
  * Added manual path input validation to check for file existence before saving the command.
* **Dedicated Prefix Configuration UI**:
  * Added a dedicated setting under Settings for the **Text/File Replacer Prefix** (defaults to `/`) to separate offline macros from API-hitting AI commands, keeping the UX clean and predictable.