### PR TITLE
Fix: Allow colon character in model names

### DIFF
--- a/app/src/main/java/com/musheer360/swiftslate/api/OpenAICompatibleClient.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/api/OpenAICompatibleClient.kt
@@ -134,7 +134,7 @@ class OpenAICompatibleClient {
             }
 
             val jsonBody = JSONObject().apply {
-                val safeModel = model.replace(Regex("[^a-zA-Z0-9._\\-/]"), "")
+                val safeModel = model.replace(Regex("[^a-zA-Z0-9._\\-/: ]"), "")
                 put("model", safeModel)
                 put("messages", JSONArray().apply {
                     put(JSONObject().apply {
@@ -246,3 +246,4 @@ class OpenAICompatibleClient {
         }
     }
 }
+


### PR DESCRIPTION

Fix: Allow colon character in model names  The model name sanitization regex in `OpenAICompatibleClient.kt` was removing the colon (`:`) from model IDs. This caused API requests to fail for models named with a suffix, such as `openai/gpt-oss-20b:free`.  The regex has been updated to permit colons, resolving the issue.

