### PR TITLE
Add clipboard commands: ?copy, ?cut, ?paste, ?replace

### DIFF
--- a/app/src/main/java/com/musheer360/swiftslate/manager/CommandManager.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/manager/CommandManager.kt
@@ -33,7 +33,11 @@ class CommandManager(context: Context) {
         "emoji" to "Add relevant emojis throughout.",
         "human" to "Rewrite to sound naturally human, not AI-generated. Never use emdashes or semicolons, use commas or periods instead. Drop AI clichés and filler phrases. Use contractions, everyday words, and varied sentence lengths. Keep all facts, names, and numbers intact.",
         "reply" to "Generate a contextual reply to this message.",
-        "undo" to "Undo the last replacement and restore the original text."
+        "undo" to "Undo the last replacement and restore the original text.",
+        "copy" to "Copy the text to clipboard.",
+        "cut" to "Cut the text to clipboard.",
+        "paste" to "Paste from clipboard.",
+        "replace" to "Replace text with clipboard content."
     )
 
     fun getTriggerPrefix(): String {

--- a/app/src/main/java/com/musheer360/swiftslate/service/AssistantService.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/service/AssistantService.kt
@@ -227,6 +227,20 @@ class AssistantService : AccessibilityService() {
             return
         }
 
+        if (command.isBuiltIn && (command.trigger.endsWith("copy") || command.trigger.endsWith("cut") ||
+            command.trigger.endsWith("paste") || command.trigger.endsWith("replace"))) {
+            if (!isProcessing.compareAndSet(false, true)) {
+                source.safeRecycle()
+                return
+            }
+            processingStartedAt = System.currentTimeMillis()
+            startWatchdog()
+            cancelPendingProcessingReset()
+            currentJob?.cancel()
+            handleClipboardCommand(source, precedingText, command)
+            return
+        }
+
         when (command.type) {
             CommandType.TEXT_REPLACER -> {
                 if (!isProcessing.compareAndSet(false, true)) {
@@ -452,6 +466,93 @@ class AssistantService : AccessibilityService() {
                 throw e
             } catch (e: Exception) {
                 showToast("Could not undo")
+            } finally {
+                withContext(NonCancellable + Dispatchers.Main) {
+                    if (currentJob === thisJob) {
+                        cancelWatchdog()
+                        processingStartedAt = 0L
+                        scheduleProcessingReset()
+                    }
+                    recycleIfUnowned(source)
+                }
+            }
+        }
+    }
+
+    private fun handleClipboardCommand(source: AccessibilityNodeInfo, precedingText: String, command: Command) {
+        currentJob = serviceScope.launch {
+            val thisJob = coroutineContext[Job]
+            try {
+                val trigger = command.trigger
+                val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                when {
+                    trigger.endsWith("copy") -> {
+                        val textToCopy = precedingText.trim()
+                        if (textToCopy.isEmpty()) {
+                            performHapticFeedback(HapticFeedbackConstants.REJECT)
+                            showToast("Nothing to copy")
+                        } else {
+                            withContext(Dispatchers.Main) {
+                                clipboard.setPrimaryClip(ClipData.newPlainText("SwiftSlate", textToCopy))
+                                replaceText(source, precedingText)
+                            }
+                            performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+                            showToast("Copied to clipboard")
+                            statsManager.recordUsage(command.trigger)
+                        }
+                    }
+                    trigger.endsWith("cut") -> {
+                        val textToCut = precedingText.trim()
+                        if (textToCut.isEmpty()) {
+                            performHapticFeedback(HapticFeedbackConstants.REJECT)
+                            showToast("Nothing to cut")
+                        } else {
+                            lastOriginalText = precedingText
+                            lastUndoSourceId = sourceId(source)
+                            withContext(Dispatchers.Main) {
+                                clipboard.setPrimaryClip(ClipData.newPlainText("SwiftSlate", textToCut))
+                                replaceText(source, "")
+                            }
+                            performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+                            showToast("Cut to clipboard")
+                            statsManager.recordUsage(command.trigger)
+                        }
+                    }
+                    trigger.endsWith("paste") -> {
+                        val clipText = clipboard.primaryClip?.getItemAt(0)?.text?.toString()
+                        if (clipText.isNullOrEmpty()) {
+                            performHapticFeedback(HapticFeedbackConstants.REJECT)
+                            showToast("Clipboard is empty")
+                        } else {
+                            lastOriginalText = precedingText
+                            lastUndoSourceId = sourceId(source)
+                            withContext(Dispatchers.Main) {
+                                replaceText(source, precedingText + clipText)
+                            }
+                            performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+                            statsManager.recordUsage(command.trigger)
+                        }
+                    }
+                    trigger.endsWith("replace") -> {
+                        val clipText = clipboard.primaryClip?.getItemAt(0)?.text?.toString()
+                        if (clipText.isNullOrEmpty()) {
+                            performHapticFeedback(HapticFeedbackConstants.REJECT)
+                            showToast("Clipboard is empty")
+                        } else {
+                            lastOriginalText = precedingText
+                            lastUndoSourceId = sourceId(source)
+                            withContext(Dispatchers.Main) {
+                                replaceText(source, clipText)
+                            }
+                            performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+                            statsManager.recordUsage(command.trigger)
+                        }
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                showToast("Clipboard operation failed")
             } finally {
                 withContext(NonCancellable + Dispatchers.Main) {
                     if (currentJob === thisJob) {


### PR DESCRIPTION
## Summary

Adds 4 new built-in local (non-AI) clipboard commands using the system clipboard:

| Command | Behavior |
|---------|----------|
| `?copy` | Copies preceding text to system clipboard, removes trigger from field |
| `?cut` | Copies preceding text to system clipboard, clears the field |
| `?paste` | Appends system clipboard content after existing text |
| `?replace` | Replaces all existing text with system clipboard content |

## Details

- **System clipboard** used intentionally (not internal) for clipboard history app compatibility
- **Undo support** for `?cut`, `?paste`, and `?replace` (not `?copy` since field doesn't change)
- Haptic feedback (confirm/reject) and toast messages
- Stats tracking only on successful operations
- Empty text/clipboard edge cases handled with reject feedback

## Implementation

Follows the exact same pattern as the existing `?undo` built-in handler:
- Detection block in `onAccessibilityEvent` (after undo, before `when(command.type)`)
- `handleClipboardCommand()` function with coroutine lifecycle management

## Changes
- `CommandManager.kt`: Added copy, cut, paste, replace to `builtInDefinitions`
- `AssistantService.kt`: Added detection block + `handleClipboardCommand()` function

Closes #57