### PR TITLE
fix: custom provider key validation with blank endpoint, remove unused network permission, and pre warm stats preferences

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <application

--- a/app/src/main/java/com/musheer360/swiftslate/SwiftSlateApp.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/SwiftSlateApp.kt
@@ -11,5 +11,6 @@ class SwiftSlateApp : Application() {
         getSharedPreferences("settings", Context.MODE_PRIVATE)
         getSharedPreferences("commands", Context.MODE_PRIVATE)
         getSharedPreferences("secure_keys_prefs", Context.MODE_PRIVATE)
+        getSharedPreferences("stats", Context.MODE_PRIVATE)
     }
 }

--- a/app/src/main/java/com/musheer360/swiftslate/ui/KeysScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/KeysScreen.kt
@@ -101,7 +101,7 @@ fun KeysScreen(keyManager: KeyManager, prefs: SharedPreferences) {
                             }
                             val result = run {
                                 val providerType = ProviderType.sanitize(prefs.getString("provider_type", null))
-                                val customEndpoint = prefs.getString("custom_endpoint", "") ?: ""
+                                val customEndpoint = (prefs.getString("custom_endpoint", "") ?: "").trim()
                                 when {
                                     providerType == ProviderType.CUSTOM && customEndpoint.isBlank() -> {
                                         isTesting = false

--- a/app/src/main/java/com/musheer360/swiftslate/ui/KeysScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/KeysScreen.kt
@@ -100,7 +100,7 @@ fun KeysScreen(keyManager: KeyManager, prefs: SharedPreferences) {
                                 return@launch
                             }
                             val result = run {
-                                val providerType = prefs.getString("provider_type", ProviderType.GEMINI) ?: ProviderType.GEMINI
+                                val providerType = ProviderType.sanitize(prefs.getString("provider_type", null))
                                 val customEndpoint = prefs.getString("custom_endpoint", "") ?: ""
                                 when {
                                     providerType == ProviderType.CUSTOM && customEndpoint.isBlank() -> {

--- a/app/src/main/java/com/musheer360/swiftslate/ui/KeysScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/KeysScreen.kt
@@ -55,6 +55,7 @@ fun KeysScreen(keyManager: KeyManager, prefs: SharedPreferences) {
     val alreadyAddedMsg = stringResource(R.string.keys_already_added)
     val validationFailedMsg = stringResource(R.string.keys_validation_failed)
     val keystoreErrorMsg = stringResource(R.string.keys_keystore_error)
+    val customEndpointRequiredMsg = stringResource(R.string.keys_custom_endpoint_required)
 
     Column(
         modifier = Modifier
@@ -102,9 +103,15 @@ fun KeysScreen(keyManager: KeyManager, prefs: SharedPreferences) {
                                 val providerType = prefs.getString("provider_type", ProviderType.GEMINI) ?: ProviderType.GEMINI
                                 val customEndpoint = prefs.getString("custom_endpoint", "") ?: ""
                                 when {
+                                    providerType == ProviderType.CUSTOM && customEndpoint.isBlank() -> {
+                                        isTesting = false
+                                        testResult = customEndpointRequiredMsg
+                                        testSuccess = false
+                                        return@launch
+                                    }
                                     providerType == ProviderType.GROQ ->
                                         openAIClient.validateKey(trimmedKey, "https://api.groq.com/openai/v1")
-                                    providerType == ProviderType.CUSTOM && customEndpoint.isNotBlank() ->
+                                    providerType == ProviderType.CUSTOM ->
                                         openAIClient.validateKey(trimmedKey, customEndpoint)
                                     else ->
                                         geminiClient.validateKey(trimmedKey)

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -20,7 +20,7 @@
     <string name="keys_valid_added">Gültiger Schlüssel hinzugefügt!</string>
     <string name="keys_already_added">Dieser Schlüssel wurde bereits hinzugefügt</string>
     <string name="keys_validation_failed">Validierung fehlgeschlagen</string>
-    <string name="keys_custom_endpoint_required">Konfiguriere zuerst die Endpunkt-URL in den Einstellungen, bevor du einen Schlüssel für den benutzerdefinierten Anbieter hinzufügst</string>
+    <string name="keys_custom_endpoint_required">Konfiguriere die Endpunkt-URL in den Einstellungen, bevor du einen Schlüssel für den benutzerdefinierten Anbieter hinzufügst</string>
     <string name="keys_get_api_key">Hol dir deinen %1$s API-Schlüssel ↗</string>
 
     <!-- Commands -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -20,6 +20,7 @@
     <string name="keys_valid_added">Gültiger Schlüssel hinzugefügt!</string>
     <string name="keys_already_added">Dieser Schlüssel wurde bereits hinzugefügt</string>
     <string name="keys_validation_failed">Validierung fehlgeschlagen</string>
+    <string name="keys_custom_endpoint_required">Konfiguriere zuerst die Endpunkt-URL in den Einstellungen, bevor du einen Schlüssel für den benutzerdefinierten Anbieter hinzufügst</string>
     <string name="keys_get_api_key">Hol dir deinen %1$s API-Schlüssel ↗</string>
 
     <!-- Commands -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -20,7 +20,7 @@
     <string name="keys_valid_added">¡Clave válida añadida!</string>
     <string name="keys_already_added">Esta clave ya fue añadida</string>
     <string name="keys_validation_failed">Error de validación</string>
-    <string name="keys_custom_endpoint_required">Configura primero la URL del endpoint en Ajustes antes de añadir una clave para el proveedor personalizado</string>
+    <string name="keys_custom_endpoint_required">Configura la URL del endpoint en Ajustes antes de añadir una clave para el proveedor personalizado</string>
     <string name="keys_get_api_key">Obtén tu clave API de %1$s ↗</string>
 
     <!-- Commands -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -20,6 +20,7 @@
     <string name="keys_valid_added">¡Clave válida añadida!</string>
     <string name="keys_already_added">Esta clave ya fue añadida</string>
     <string name="keys_validation_failed">Error de validación</string>
+    <string name="keys_custom_endpoint_required">Configura primero la URL del endpoint en Ajustes antes de añadir una clave para el proveedor personalizado</string>
     <string name="keys_get_api_key">Obtén tu clave API de %1$s ↗</string>
 
     <!-- Commands -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -20,7 +20,7 @@
     <string name="keys_valid_added">Clé valide ajoutée !</string>
     <string name="keys_already_added">Cette clé a déjà été ajoutée</string>
     <string name="keys_validation_failed">Échec de la validation</string>
-    <string name="keys_custom_endpoint_required">Configurez d\'abord l\'URL de l\'endpoint dans les Paramètres avant d\'ajouter une clé pour le fournisseur personnalisé</string>
+    <string name="keys_custom_endpoint_required">Configurez l\'URL de l\'endpoint dans les Paramètres avant d\'ajouter une clé pour le fournisseur personnalisé</string>
     <string name="keys_get_api_key">Obtenez votre clé API %1$s ↗</string>
 
     <!-- Commands -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -20,6 +20,7 @@
     <string name="keys_valid_added">Clé valide ajoutée !</string>
     <string name="keys_already_added">Cette clé a déjà été ajoutée</string>
     <string name="keys_validation_failed">Échec de la validation</string>
+    <string name="keys_custom_endpoint_required">Configurez d\'abord l\'URL de l\'endpoint dans les Paramètres avant d\'ajouter une clé pour le fournisseur personnalisé</string>
     <string name="keys_get_api_key">Obtenez votre clé API %1$s ↗</string>
 
     <!-- Commands -->

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -20,6 +20,7 @@
     <string name="keys_valid_added">मान्य कुंजी जोड़ी गई!</string>
     <string name="keys_already_added">यह कुंजी पहले से जोड़ी जा चुकी है</string>
     <string name="keys_validation_failed">सत्यापन विफल</string>
+    <string name="keys_custom_endpoint_required">कस्टम प्रदाता के लिए कुंजी जोड़ने से पहले सेटिंग्स में एंडपॉइंट URL कॉन्फ़िगर करें</string>
     <string name="keys_get_api_key">अपनी %1$s API कुंजी प्राप्त करें ↗</string>
 
     <!-- Commands -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -20,6 +20,7 @@
     <string name="keys_valid_added">Chave válida adicionada!</string>
     <string name="keys_already_added">Esta chave já foi adicionada</string>
     <string name="keys_validation_failed">Falha na validação</string>
+    <string name="keys_custom_endpoint_required">Configure primeiro a URL do endpoint em Configurações antes de adicionar uma chave para o provedor personalizado</string>
     <string name="keys_get_api_key">Obtenha sua chave API %1$s ↗</string>
 
     <!-- Commands -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -20,7 +20,7 @@
     <string name="keys_valid_added">Chave válida adicionada!</string>
     <string name="keys_already_added">Esta chave já foi adicionada</string>
     <string name="keys_validation_failed">Falha na validação</string>
-    <string name="keys_custom_endpoint_required">Configure primeiro a URL do endpoint em Configurações antes de adicionar uma chave para o provedor personalizado</string>
+    <string name="keys_custom_endpoint_required">Configure a URL do endpoint em Configurações antes de adicionar uma chave para o provedor personalizado</string>
     <string name="keys_get_api_key">Obtenha sua chave API %1$s ↗</string>
 
     <!-- Commands -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -20,6 +20,7 @@
     <string name="keys_valid_added">有效密钥已添加！</string>
     <string name="keys_already_added">此密钥已添加过</string>
     <string name="keys_validation_failed">验证失败</string>
+    <string name="keys_custom_endpoint_required">在添加自定义提供商的密钥之前，请先在设置中配置端点 URL</string>
     <string name="keys_get_api_key">获取您的 %1$s API 密钥 ↗</string>
 
     <!-- Commands -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,7 +25,7 @@
     <string name="keys_already_added">This key has already been added</string>
     <string name="keys_validation_failed">Validation failed</string>
     <string name="keys_keystore_error">Secure key storage is unavailable on this device. Keys cannot be saved.</string>
-    <string name="keys_custom_endpoint_required">Set the endpoint URL in Settings first before adding a key for Custom provider</string>
+    <string name="keys_custom_endpoint_required">Set the endpoint URL in Settings before adding a key for the Custom provider</string>
     <string name="keys_get_api_key">Get your %1$s API key ↗</string>
     <string name="keys_empty">No API keys added</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="keys_already_added">This key has already been added</string>
     <string name="keys_validation_failed">Validation failed</string>
     <string name="keys_keystore_error">Secure key storage is unavailable on this device. Keys cannot be saved.</string>
+    <string name="keys_custom_endpoint_required">Set the endpoint URL in Settings first before adding a key for Custom provider</string>
     <string name="keys_get_api_key">Get your %1$s API key ↗</string>
     <string name="keys_empty">No API keys added</string>
 


### PR DESCRIPTION
The first and most impactful fix is in the Keys screen. When a user selects the Custom provider type but hasn't configured an endpoint URL in settings, attempting to add an API key would silently fall through to Gemini validation. The key would be rejected by Gemini and the user would see a generic "Validation failed" error with no indication that the real problem was a missing endpoint URL. The fix adds an early check for this case. If the provider is Custom and the endpoint is blank, the app now shows a clear error message telling the user to set the endpoint URL in Settings first. A new string resource was added in all seven supported languages to support this message.

The second change removes the ACCESS_NETWORK_STATE permission from the Android manifest. A search through the entire source code confirmed that this permission is never used anywhere in the app. Removing it keeps the manifest clean and reduces unnecessary permission declarations.

The third change pre warms the stats SharedPreferences file in the Application class. The app already pre warmed three other preference files (settings, commands, and secure keys prefs) during startup so they would be loaded into memory by the time they were needed. The stats preferences were missing from this list even though they are used by both the ViewModel and the Assistant service. Adding the pre warm call ensures consistent behavior and avoids a potential first access delay on the stats file.
All changes compile successfully and the existing unit tests continue to pass.