### PR TITLE
Run trigger commands from the text-selection popup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,11 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/*" />
             </intent-filter>
+            <!-- Makes this package visible to custom editors that omit a PROCESS_TEXT query. -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <data android:scheme="https" />
+            </intent-filter>
         </activity>
 
         <service

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@
             <!-- Makes this package visible to custom editors that omit a PROCESS_TEXT query. -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="https" />
             </intent-filter>
         </activity>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
             Text-selection entry point. android:label is what the popup shows (it would fall back
             to the app label anyway; it is set explicitly so renaming the app cannot silently
             change the menu item). All three filter elements are required: an implicit intent
-            needs category.DEFAULT, and the system only queries PROCESS_TEXT for text/plain.
+            needs category.DEFAULT. text/* also covers hosts that offer rich-text selections.
         -->
         <activity
             android:name=".ui.processtext.ProcessTextActivity"
@@ -45,7 +45,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.PROCESS_TEXT" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="text/plain" />
+                <data android:mimeType="text/*" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,25 @@
             </intent-filter>
         </activity>
 
+        <!--
+            Text-selection entry point. android:label is what the popup shows (it would fall back
+            to the app label anyway; it is set explicitly so renaming the app cannot silently
+            change the menu item). All three filter elements are required: an implicit intent
+            needs category.DEFAULT, and the system only queries PROCESS_TEXT for text/plain.
+        -->
+        <activity
+            android:name=".ui.processtext.ProcessTextActivity"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:excludeFromRecents="true"
+            android:theme="@style/Theme.SwiftSlate.Dialog">
+            <intent-filter>
+                <action android:name="android.intent.action.PROCESS_TEXT" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+        </activity>
+
         <service
             android:name=".service.AssistantService"
             android:exported="true"

--- a/app/src/main/java/com/musheer360/swiftslate/SwiftSlateApp.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/SwiftSlateApp.kt
@@ -7,10 +7,22 @@ import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
+import com.musheer360.swiftslate.manager.KeyManager
 import com.musheer360.swiftslate.worker.UpdateCheckWorker
 import java.util.concurrent.TimeUnit
 
 class SwiftSlateApp : Application() {
+    /**
+     * The one KeyManager for the process. Rate-limit benching, invalid-key marks and the
+     * round-robin cursor are in-memory only, so a second instance starts blind: it re-tries keys
+     * another instance already knows are benched, and never learns what that one learned. It also
+     * breaks [KeyManager.addKey]'s un-benching — re-adding a key in the UI cleared the invalid
+     * mark on the UI's instance while the accessibility service kept benching it for the full TTL.
+     *
+     * Lazy so the Keystore round trip in the constructor stays off Application.onCreate.
+     */
+    val keyManager: KeyManager by lazy { KeyManager(this) }
+
     override fun onCreate() {
         super.onCreate()
         // Pre-warm SharedPreferences — triggers async disk load so they're

--- a/app/src/main/java/com/musheer360/swiftslate/SwiftSlateViewModel.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/SwiftSlateViewModel.kt
@@ -5,12 +5,11 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.lifecycle.AndroidViewModel
 import com.musheer360.swiftslate.manager.CommandManager
-import com.musheer360.swiftslate.manager.KeyManager
 import com.musheer360.swiftslate.manager.StatsManager
 
 class SwiftSlateViewModel(application: Application) : AndroidViewModel(application) {
     val prefs: SharedPreferences = application.getSharedPreferences("settings", Context.MODE_PRIVATE)
-    val keyManager = KeyManager(application)
+    val keyManager = (application as SwiftSlateApp).keyManager
     val commandManager = CommandManager(application)
     val statsManager = StatsManager(application)
 }

--- a/app/src/main/java/com/musheer360/swiftslate/manager/KeyManager.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/manager/KeyManager.kt
@@ -47,8 +47,9 @@ class KeyManager internal constructor(
     /**
      * Ciphertext [cachedKeys] was decrypted from, so an expired TTL can be revalidated with a
      * string compare instead of another AndroidKeyStore round trip + AES-GCM decrypt. The TTL
-     * itself has to stay: the UI and the accessibility service hold separate KeyManager
-     * instances in one process, and this is how one notices the other's writes.
+     * used to be what let the UI's instance notice the accessibility service's writes; every
+     * caller now shares [com.musheer360.swiftslate.SwiftSlateApp.keyManager], so it is only a
+     * backstop against prefs changing underneath a single instance.
      */
     @Volatile
     private var cachedCipherText: String? = null

--- a/app/src/main/java/com/musheer360/swiftslate/service/AssistantService.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/service/AssistantService.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.os.VibratorManager
@@ -21,6 +22,9 @@ import com.musheer360.swiftslate.manager.KeyManager
 import com.musheer360.swiftslate.manager.StatsManager
 import com.musheer360.swiftslate.model.Command
 import com.musheer360.swiftslate.model.CommandType
+import com.musheer360.swiftslate.ui.processtext.ProcessTextEdit
+import com.musheer360.swiftslate.ui.processtext.ProcessTextReplacementBridge
+import com.musheer360.swiftslate.ui.processtext.resolveProcessTextEdit
 import com.musheer360.swiftslate.R
 import com.musheer360.swiftslate.SwiftSlateApp
 import kotlinx.coroutines.CancellationException
@@ -167,13 +171,17 @@ class AssistantService : AccessibilityService() {
         if (event.packageName?.toString() == packageName) return
         if (!::keyManager.isInitialized) return
 
-        if (isProcessing.get()) return
         val source = event.source ?: return
         if (source.isPassword) {
             source.safeRecycle()
             return
         }
         val text = source.text?.toString() ?: run {
+            source.safeRecycle()
+            return
+        }
+        if (handlePendingProcessTextReplacement(event, source, text)) return
+        if (isProcessing.get()) {
             source.safeRecycle()
             return
         }
@@ -300,6 +308,73 @@ class AssistantService : AccessibilityService() {
                 processCommand(source, cleanText, command)
             }
         }
+    }
+
+    private fun handlePendingProcessTextReplacement(
+        event: AccessibilityEvent,
+        source: AccessibilityNodeInfo,
+        afterText: String
+    ): Boolean {
+        val request = ProcessTextReplacementBridge.current(SystemClock.elapsedRealtime())
+            ?: return false
+        if (request.sourcePackage != null &&
+            event.packageName?.toString() != request.sourcePackage) {
+            return false
+        }
+        val beforeText = event.beforeText?.toString() ?: return false
+        val edit = resolveProcessTextEdit(
+            beforeText = beforeText,
+            afterText = afterText,
+            fromIndex = event.fromIndex,
+            removedCount = event.removedCount,
+            addedCount = event.addedCount,
+            request = request
+        )
+        if (edit == ProcessTextEdit.Unrelated ||
+            !ProcessTextReplacementBridge.consume(request)) {
+            return false
+        }
+        if (edit == ProcessTextEdit.Replaced) {
+            source.safeRecycle()
+            return true
+        }
+
+        edit as ProcessTextEdit.Appended
+        if (!isProcessing.compareAndSet(false, true)) {
+            source.safeRecycle()
+            return true
+        }
+        startWatchdog()
+        cancelPendingProcessingReset()
+        currentJob = serviceScope.launch {
+            val thisJob = coroutineContext[Job]
+            try {
+                val replaced = replaceText(source, edit.correctedText)
+                if (replaced) {
+                    lastOriginalText = beforeText
+                    lastUndoSourceId = sourceId(source)
+                } else {
+                    withContext(Dispatchers.Main) {
+                        showToast(getString(R.string.toast_replace_failed))
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                withContext(Dispatchers.Main) {
+                    showToast(getString(R.string.toast_replace_failed))
+                }
+            } finally {
+                withContext(NonCancellable + Dispatchers.Main) {
+                    if (currentJob === thisJob) {
+                        cancelWatchdog()
+                        scheduleProcessingReset()
+                    }
+                    recycleIfUnowned(source)
+                }
+            }
+        }
+        return true
     }
 
     private fun processCommand(source: AccessibilityNodeInfo, text: String, command: Command) {

--- a/app/src/main/java/com/musheer360/swiftslate/service/AssistantService.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/service/AssistantService.kt
@@ -22,6 +22,7 @@ import com.musheer360.swiftslate.manager.StatsManager
 import com.musheer360.swiftslate.model.Command
 import com.musheer360.swiftslate.model.CommandType
 import com.musheer360.swiftslate.R
+import com.musheer360.swiftslate.SwiftSlateApp
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -99,7 +100,7 @@ class AssistantService : AccessibilityService() {
 
     override fun onServiceConnected() {
         super.onServiceConnected()
-        keyManager = KeyManager(applicationContext)
+        keyManager = (applicationContext as SwiftSlateApp).keyManager
         commandManager = CommandManager(applicationContext)
         statsManager = StatsManager(applicationContext)
         updateTriggers()

--- a/app/src/main/java/com/musheer360/swiftslate/service/AssistantService.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/service/AssistantService.kt
@@ -14,20 +14,13 @@ import android.os.VibratorManager
 import android.view.HapticFeedbackConstants
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
-import com.musheer360.swiftslate.api.ApiClientUtils
-import com.musheer360.swiftslate.api.ApiError
-import com.musheer360.swiftslate.api.ApiException
 import com.musheer360.swiftslate.api.GeminiClient
-import com.musheer360.swiftslate.api.GenerateResult
 import com.musheer360.swiftslate.api.OpenAICompatibleClient
 import com.musheer360.swiftslate.manager.CommandManager
 import com.musheer360.swiftslate.manager.KeyManager
 import com.musheer360.swiftslate.manager.StatsManager
 import com.musheer360.swiftslate.model.Command
 import com.musheer360.swiftslate.model.CommandType
-import com.musheer360.swiftslate.model.PrefKeys
-import com.musheer360.swiftslate.provider.Providers
-import com.musheer360.swiftslate.provider.Transport
 import com.musheer360.swiftslate.R
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -100,7 +93,6 @@ class AssistantService : AccessibilityService() {
 
     private companion object {
         const val TRIGGER_REFRESH_INTERVAL_MS = 5_000L
-        const val DEFAULT_TEMPERATURE = 0.5
         const val PROCESSING_WATCHDOG_MS = 120_000L
         val SPINNER_FRAMES = arrayOf("◐", "◓", "◑", "◒")
     }
@@ -324,181 +316,52 @@ class AssistantService : AccessibilityService() {
 
         currentJob = serviceScope.launch {
             val thisJob = coroutineContext[Job]
-            val prefs = applicationContext.getSharedPreferences("settings", Context.MODE_PRIVATE)
-            val provider = Providers.forType(prefs.getString(PrefKeys.PROVIDER_TYPE, null))
-            val model = provider.sanitizeModel(prefs.getString(provider.modelPrefKey, provider.defaultModel))
-            val endpoint = provider.resolveEndpoint(prefs.getString(PrefKeys.CUSTOM_ENDPOINT, "") ?: "")
-
-            if (!provider.isConfigured(model, endpoint)) {
-                showToast(getString(R.string.toast_custom_not_configured))
-                withContext(NonCancellable + Dispatchers.Main) {
-                    cancelWatchdog()
-                    scheduleProcessingReset()
-                    recycleIfUnowned(source)
-                }
-                return@launch
-            }
-            val temperature = prefs.getFloat(PrefKeys.TEMPERATURE, DEFAULT_TEMPERATURE.toFloat()).toDouble()
-            val useStructuredOutput = run {
-                val disabledAt = prefs.getLong(PrefKeys.STRUCTURED_OUTPUT_DISABLED_AT, 0L)
-                System.currentTimeMillis() - disabledAt > 86_400_000L // re-try after 24h
-            }
-
             val originalText = text
             var spinnerJob: Job? = null
             try {
-                withTimeout(90_000) {
-                    val maxAttempts = keyManager.getKeys().size.coerceAtLeast(1)
-                    var lastErrorMsg: String? = null
-                    var lastErrorWasRateLimit = false
-                    var lastErrorWasPermission = false
-                    var lastFailedKey: String? = null
-                    var spinnerEverStarted = false
-                    val triedKeys = mutableSetOf<String>()
-                    var succeeded = false
+                val outcome = withTimeout(90_000) {
+                    runTextCommand(
+                        applicationContext, keyManager, client, openAIClient,
+                        command.prompt, text
+                    ) { spinnerJob = startInlineSpinner(source, originalText) }
+                }
+                // From the first attempt onward the field holds the spinner glyph instead of the
+                // user's text, so every outcome below starts by taking it back out. No spinner
+                // means no usable key was ever found and the field was never touched — a failed
+                // no-op write must not produce a "could not restore your text" prefix.
+                val fieldWasAltered = spinnerJob != null
+                spinnerJob?.cancelAndJoin()
+                spinnerJob = null
 
-                    for (attempt in 0 until maxAttempts) {
-                        val key = keyManager.getNextKey(triedKeys)
-                        if (key == null) break
-                        triedKeys.add(key)
-
-                        if (spinnerJob == null) {
-                            spinnerJob = startInlineSpinner(source, originalText)
-                            spinnerEverStarted = true
-                        }
-
-                        val result = when (provider.transport) {
-                            Transport.OPENAI_COMPAT -> openAIClient.generate(
-                                command.prompt, text, key, model, temperature, endpoint,
-                                useJsonObjectMode = provider.useJsonObjectMode(useStructuredOutput),
-                                extraParams = provider.reasoningParams(model))
-                            Transport.GEMINI_NATIVE -> client.generate(
-                                command.prompt, text, key, model, temperature, useStructuredOutput,
-                                thinkingLevel = provider.thinkingLevel(model))
-                        }
-
-                        if (result.isSuccess) {
-                            spinnerJob.cancelAndJoin()
-                            spinnerJob = null
-                            val generateResult = result.getOrThrow()
-
-                            if (ApiClientUtils.isModelRefusal(generateResult.text)) {
-                                replaceText(source, originalText)
-                                performHapticFeedback(HapticFeedbackConstants.REJECT)
-                                showToast(getString(R.string.error_safety_blocked))
-                                succeeded = true
-                                break
-                            }
-
-                            // The truncation note is appended here, not in the client: the
-                            // clients have no Context, so they used to splice an English
-                            // "[Note: Response may be truncated]" into the user's field
-                            // regardless of locale.
-                            val outputText = if (generateResult.truncated) {
-                                generateResult.text + "\n\n" + getString(R.string.note_response_truncated)
-                            } else {
-                                generateResult.text
-                            }
-
-                            if (!replaceText(source, outputText)) {
-                                // The field rejected the write. Restore the user's text (the
-                                // spinner glyph is still in it), and don't record an undo point
-                                // or a CONFIRM haptic for text that never landed.
-                                replaceText(source, originalText)
-                                performHapticFeedback(HapticFeedbackConstants.REJECT)
-                                showToast(getString(R.string.toast_replace_failed))
-                                succeeded = true // suppress the generic failure message below
-                                break
-                            }
+                when (outcome) {
+                    is CommandOutcome.Success -> {
+                        if (!replaceText(source, outcome.text)) {
+                            // The field rejected the write. Restore the user's text, and don't
+                            // record an undo point or a CONFIRM haptic for text that never landed.
+                            replaceText(source, originalText)
+                            performHapticFeedback(HapticFeedbackConstants.REJECT)
+                            showToast(getString(R.string.toast_replace_failed))
+                        } else {
                             lastOriginalText = originalText
                             lastUndoSourceId = sourceId(source)
                             performHapticFeedback(HapticFeedbackConstants.CONFIRM)
-                            if (generateResult.structuredOutputFailed) {
-                                prefs.edit().putLong(PrefKeys.STRUCTURED_OUTPUT_DISABLED_AT, System.currentTimeMillis()).apply()
-                            }
-                            succeeded = true
                             statsManager.recordUsage(command.trigger)
-                            break
-                        }
-
-                        val msg = result.exceptionOrNull()?.message ?: ""
-                        lastErrorMsg = msg
-                        val apiError = (result.exceptionOrNull() as? ApiException)?.apiError
-
-                        when (apiError) {
-                            is ApiError.RateLimit -> {
-                                lastErrorWasRateLimit = true
-                                val seconds = apiError.retryAfterSeconds?.toLong() ?: 60
-                                keyManager.reportRateLimit(key, seconds)
-                            }
-                            is ApiError.RequestTooLarge -> {
-                                lastErrorWasRateLimit = false
-                                break // Fail fast: TPM budget is per org/account, key rotation won't help
-                            }
-                            is ApiError.InvalidKey -> {
-                                lastErrorWasRateLimit = false
-                                lastFailedKey = key
-                                // Distinguish "this key is bad" from "this key may not use this
-                                // model" (both arrive as 401/403) so the final message can be
-                                // truthful about which one the user should go fix.
-                                val m = msg.lowercase(java.util.Locale.ROOT)
-                                lastErrorWasPermission = m.contains("permission") ||
-                                    m.contains("does not have access") || m.contains("not been used in project")
-                                keyManager.markInvalid(key)
-                            }
-                            is ApiError.ServerError -> {
-                                lastErrorWasRateLimit = false
-                                continue // 5xx — try next key
-                            }
-                            else -> {
-                                // Non-retryable. Clear the flag so a 400 arriving after an earlier
-                                // 429 is not reported as a rate limit with a bogus countdown.
-                                lastErrorWasRateLimit = false
-                                break
-                            }
                         }
                     }
-
-                    if (!succeeded) {
-                        spinnerJob?.cancelAndJoin()
-                        spinnerJob = null
-                        // Only restore when the field was actually altered: with no usable keys
-                        // no spinner ever ran, so a failed no-op write must not produce a
-                        // "could not restore your text" prefix.
-                        val fieldWasAltered = spinnerEverStarted
+                    is CommandOutcome.Refusal -> {
+                        replaceText(source, originalText)
+                        performHapticFeedback(HapticFeedbackConstants.REJECT)
+                        showToast(getString(R.string.error_safety_blocked))
+                    }
+                    // Nothing was sent, so there is nothing to restore.
+                    is CommandOutcome.Unavailable -> showToast(outcome.message)
+                    is CommandOutcome.Failure -> {
                         val restoredOk = !fieldWasAltered || replaceText(source, originalText)
                         performHapticFeedback(HapticFeedbackConstants.REJECT)
-                        val restorePrefix = if (restoredOk) "" else getString(R.string.toast_restore_failed) + "\n"
-                        // Prefer the message that carries the actual wait time. It used to be
-                        // reachable only when nothing had been attempted, so the request that
-                        // *discovered* the rate limit showed the vague "Rate limited. Try again
-                        // shortly." and only a later request showed the seconds — the useful
-                        // message lost the common path. Gated on the last error actually being a
-                        // rate limit, so an unrelated failure still reports its own cause even
-                        // when some other key happens to be cooling down.
-                        val waitMs = keyManager.getShortestWaitTimeMs()
-                        if (waitMs != null && (lastErrorMsg == null || lastErrorWasRateLimit)) {
-                            val waitSec = ((waitMs + 999) / 1000).coerceAtLeast(1)
-                            showToast(restorePrefix + getString(R.string.toast_key_rate_limited, waitSec))
-                        } else if (lastErrorWasPermission) {
-                            // Must precede the generic branch: lastErrorMsg is never null once a
-                            // request was attempted, so this was unreachable below it. A 403 is
-                            // usually the selected model not being available to the project
-                            // rather than bad keys, so don't send the user to check good keys.
-                            showToast(restorePrefix + getString(R.string.error_no_model_access))
-                        } else if (lastErrorMsg != null) {
-                            val mapped = mapErrorMessage(lastErrorMsg)
-                            if (mapped == getString(R.string.error_invalid_key) && keyManager.getKeys().size > 1 && lastFailedKey != null) {
-                                val hint = "••••" + lastFailedKey.takeLast(4)
-                                showToast(restorePrefix + getString(R.string.error_invalid_key_with_hint, hint))
-                            } else {
-                                showToast(restorePrefix + mapped)
-                            }
-                        } else if (keyManager.getKeys().isEmpty()) {
-                            showToast(restorePrefix + getString(R.string.toast_no_keys))
-                        } else {
-                            showToast(restorePrefix + getString(R.string.toast_all_keys_invalid))
-                        }
+                        showToast(
+                            if (restoredOk) outcome.message
+                            else getString(R.string.toast_restore_failed) + "\n" + outcome.message
+                        )
                     }
                 }
             } catch (e: TimeoutCancellationException) {

--- a/app/src/main/java/com/musheer360/swiftslate/service/CommandRunner.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/service/CommandRunner.kt
@@ -1,0 +1,168 @@
+package com.musheer360.swiftslate.service
+
+import android.content.Context
+import com.musheer360.swiftslate.R
+import com.musheer360.swiftslate.api.ApiClientUtils
+import com.musheer360.swiftslate.api.ApiError
+import com.musheer360.swiftslate.api.ApiException
+import com.musheer360.swiftslate.api.GeminiClient
+import com.musheer360.swiftslate.api.OpenAICompatibleClient
+import com.musheer360.swiftslate.manager.KeyManager
+import com.musheer360.swiftslate.model.PrefKeys
+import com.musheer360.swiftslate.provider.Providers
+import com.musheer360.swiftslate.provider.Transport
+import java.util.Locale
+
+sealed interface CommandOutcome {
+    data class Success(val text: String) : CommandOutcome
+    /** The model refused in-band. Its answer, not a fault — re-running the same prompt won't help. */
+    data object Refusal : CommandOutcome
+    /** Nothing was sent and nothing will be until the user changes something. */
+    data class Unavailable(val message: String) : CommandOutcome
+    /** A request was attempted and failed. Retrying may work. */
+    data class Failure(val message: String) : CommandOutcome
+}
+
+private const val DEFAULT_TEMPERATURE = 0.5f
+private const val STRUCTURED_OUTPUT_RETRY_MS = 86_400_000L // re-try structured output after 24h
+
+/**
+ * Everything a trigger command does between "user asked" and "text came back": provider
+ * resolution, key rotation, rate-limit benching and error mapping. Both entry points call this
+ * — the accessibility service for a typed `?trigger`, the text-selection sheet for a tapped
+ * one — so a fix to the request policy lands in both at once.
+ *
+ * Knows nothing about how the result is delivered: no nodes, no toasts, no UI state. Suspends
+ * on the caller's dispatcher and reads disk (prefs, Keystore), so call it off the main thread.
+ *
+ * @param onFirstAttempt run just before the first request actually goes out — after it is known
+ *   that a usable key exists. The service starts its inline spinner here.
+ */
+suspend fun runTextCommand(
+    context: Context,
+    keyManager: KeyManager,
+    geminiClient: GeminiClient,
+    openAIClient: OpenAICompatibleClient,
+    prompt: String,
+    text: String,
+    onFirstAttempt: () -> Unit = {}
+): CommandOutcome {
+    // keys_keystore_error rather than a "reinstall" message: the usual cause is the Keystore key
+    // being invalidated by a lock-screen change, where re-adding the keys is enough.
+    if (!keyManager.keystoreAvailable) {
+        return CommandOutcome.Unavailable(context.getString(R.string.keys_keystore_error))
+    }
+
+    val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
+    val provider = Providers.forType(prefs.getString(PrefKeys.PROVIDER_TYPE, null))
+    val model = provider.sanitizeModel(prefs.getString(provider.modelPrefKey, provider.defaultModel))
+    val endpoint = provider.resolveEndpoint(prefs.getString(PrefKeys.CUSTOM_ENDPOINT, "") ?: "")
+    if (!provider.isConfigured(model, endpoint)) {
+        return CommandOutcome.Unavailable(context.getString(R.string.toast_custom_not_configured))
+    }
+    val temperature = prefs.getFloat(PrefKeys.TEMPERATURE, DEFAULT_TEMPERATURE).toDouble()
+    val useStructuredOutput = System.currentTimeMillis() -
+        prefs.getLong(PrefKeys.STRUCTURED_OUTPUT_DISABLED_AT, 0L) > STRUCTURED_OUTPUT_RETRY_MS
+
+    var lastErrorMsg: String? = null
+    var lastErrorWasRateLimit = false
+    var lastErrorWasPermission = false
+    var lastFailedKey: String? = null
+    var started = false
+    val tried = mutableSetOf<String>()
+
+    // One attempt per configured key; getNextKey skips the ones already tried, plus any that are
+    // benched for rate limiting or known-invalid.
+    val maxAttempts = keyManager.getKeys().size.coerceAtLeast(1)
+    while (tried.size < maxAttempts) {
+        val key = keyManager.getNextKey(tried) ?: break
+        tried.add(key)
+        if (!started) {
+            started = true
+            onFirstAttempt()
+        }
+
+        val result = when (provider.transport) {
+            Transport.OPENAI_COMPAT -> openAIClient.generate(
+                prompt, text, key, model, temperature, endpoint,
+                useJsonObjectMode = provider.useJsonObjectMode(useStructuredOutput),
+                extraParams = provider.reasoningParams(model))
+            Transport.GEMINI_NATIVE -> geminiClient.generate(
+                prompt, text, key, model, temperature, useStructuredOutput,
+                thinkingLevel = provider.thinkingLevel(model))
+        }
+
+        result.onSuccess { generated ->
+            if (ApiClientUtils.isModelRefusal(generated.text)) return CommandOutcome.Refusal
+            if (generated.structuredOutputFailed) {
+                prefs.edit()
+                    .putLong(PrefKeys.STRUCTURED_OUTPUT_DISABLED_AT, System.currentTimeMillis())
+                    .apply()
+            }
+            // Keep the truncation warning localized and shared by both entry points rather than
+            // leaving callers to duplicate it (or clients to inject an English-only string).
+            val outputText = if (generated.truncated) {
+                generated.text + "\n\n" + context.getString(R.string.note_response_truncated)
+            } else {
+                generated.text
+            }
+            return CommandOutcome.Success(outputText)
+        }
+
+        val error = result.exceptionOrNull()
+        val msg = error?.message ?: ""
+        lastErrorMsg = msg
+        when (val apiError = (error as? ApiException)?.apiError) {
+            is ApiError.RateLimit -> {
+                lastErrorWasRateLimit = true
+                keyManager.reportRateLimit(key, apiError.retryAfterSeconds?.toLong() ?: 60)
+            }
+            is ApiError.InvalidKey -> {
+                lastErrorWasRateLimit = false
+                lastFailedKey = key
+                // Distinguish "this key is bad" from "this key may not use this model" (both
+                // arrive as 401/403) so the final message names the right fix.
+                val m = msg.lowercase(Locale.ROOT)
+                lastErrorWasPermission = m.contains("permission") ||
+                    m.contains("does not have access") || m.contains("not been used in project")
+                keyManager.markInvalid(key)
+            }
+            // 5xx — try the next key.
+            is ApiError.ServerError -> lastErrorWasRateLimit = false
+            else -> {
+                // Rotating keys cannot help: RequestTooLarge is a per-account token budget, the
+                // rest are non-retryable. Clear the flag so a 400 arriving after an earlier 429
+                // is not reported as a rate limit with a bogus countdown.
+                lastErrorWasRateLimit = false
+                break
+            }
+        }
+    }
+
+    val waitMs = keyManager.getShortestWaitTimeMs()
+    val failedKey = lastFailedKey
+    val raw = lastErrorMsg
+    return CommandOutcome.Failure(
+        when {
+            // Prefer the message carrying the actual wait time, but only when the last error
+            // really was a rate limit — otherwise an unrelated failure would be masked by some
+            // other key that merely happens to be cooling down.
+            waitMs != null && (raw == null || lastErrorWasRateLimit) ->
+                context.getString(R.string.toast_key_rate_limited, ((waitMs + 999) / 1000).coerceAtLeast(1))
+            // Must precede the generic branch: raw is never null once a request was attempted. A
+            // 403 is usually the selected model not being available to the project rather than
+            // bad keys, so don't send the user off to check keys that are fine.
+            lastErrorWasPermission -> context.getString(R.string.error_no_model_access)
+            raw != null -> {
+                val mapped = ErrorMessages.map(raw)
+                if (mapped == R.string.error_invalid_key && failedKey != null && keyManager.getKeys().size > 1) {
+                    context.getString(R.string.error_invalid_key_with_hint, "••••" + failedKey.takeLast(4))
+                } else {
+                    context.getString(mapped)
+                }
+            }
+            keyManager.getKeys().isEmpty() -> context.getString(R.string.toast_no_keys)
+            else -> context.getString(R.string.toast_all_keys_invalid)
+        }
+    )
+}

--- a/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextActivity.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextActivity.kt
@@ -9,6 +9,11 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -31,7 +36,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,6 +43,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
@@ -71,7 +76,7 @@ class ProcessTextActivity : ComponentActivity() {
             // Finish with a short toast rather than showing an empty sheet.
             val message = when ((e as? RejectedSelectionException)?.rejection) {
                 Rejection.TooLong -> getString(R.string.error_input_too_long)
-                else -> getString(R.string.process_text_no_selection)
+                Rejection.Missing, null -> getString(R.string.process_text_no_selection)
             }
             Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
             finish()
@@ -119,10 +124,14 @@ private fun ProcessTextSheet(
     onCopy: (String) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val state by viewModel.uiState.collectAsState()
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
-    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.background
+    ) {
         Column(modifier = Modifier.padding(horizontal = 20.dp).padding(bottom = 24.dp)) {
             Text(
                 text = stringResource(R.string.process_text_title),
@@ -132,65 +141,89 @@ private fun ProcessTextSheet(
                 modifier = Modifier.padding(bottom = 12.dp)
             )
 
-            when (val s = state) {
-                is UiState.CommandList -> CommandRows(s.commands) { viewModel.run(it) }
-                is UiState.Loading -> Row(verticalAlignment = Alignment.CenterVertically) {
-                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
-                    Spacer(Modifier.width(12.dp))
-                    Text(
-                        text = s.command.trigger,
-                        fontSize = 14.sp,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                is UiState.Preview -> {
-                    Text(
-                        text = s.result,
-                        fontSize = 15.sp,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier
-                            .heightIn(max = 240.dp)
-                            .verticalScroll(rememberScrollState())
-                    )
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        if (s.canInsert) {
-                            Button(onClick = { onInsert(s.result) }) {
-                                Text(stringResource(R.string.process_text_insert))
-                            }
-                        }
-                        // Always offered, editable or not: it is also the recovery path when a
-                        // host silently declines the replacement.
-                        OutlinedButton(onClick = { onCopy(s.result) }) {
-                            Text(stringResource(R.string.process_text_copy))
-                        }
-                        TextButton(onClick = { viewModel.backToCommands() }) {
-                            Text(stringResource(R.string.process_text_back))
-                        }
+            AnimatedContent(
+                targetState = state,
+                transitionSpec = {
+                    val direction = if (targetState is UiState.CommandList) {
+                        AnimatedContentTransitionScope.SlideDirection.Down
+                    } else {
+                        AnimatedContentTransitionScope.SlideDirection.Up
+                    }
+                    slideIntoContainer(direction, tween(250, easing = FastOutSlowInEasing)) togetherWith
+                        slideOutOfContainer(direction, tween(250, easing = FastOutSlowInEasing))
+                },
+                contentKey = { it::class },
+                label = "process_text_transition"
+            ) { currentState ->
+                ProcessTextContent(currentState, viewModel, onInsert, onCopy)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProcessTextContent(
+    state: UiState,
+    viewModel: ProcessTextViewModel,
+    onInsert: (String) -> Unit,
+    onCopy: (String) -> Unit
+) {
+    when (state) {
+        is UiState.CommandList -> CommandRows(state.commands) { viewModel.run(it) }
+        is UiState.Loading -> Row(verticalAlignment = Alignment.CenterVertically) {
+            CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = state.command.trigger,
+                fontSize = 14.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        is UiState.Preview -> {
+            Text(
+                text = state.result,
+                fontSize = 15.sp,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier
+                    .heightIn(max = 240.dp)
+                    .verticalScroll(rememberScrollState())
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                if (state.canInsert) {
+                    Button(onClick = { onInsert(state.result) }) {
+                        Text(stringResource(R.string.process_text_insert))
                     }
                 }
-                is UiState.Error -> {
-                    Text(
-                        text = s.message,
-                        fontSize = 14.sp,
-                        color = MaterialTheme.colorScheme.error
-                    )
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        // Offered only for failures a re-run could actually fix.
-                        s.retry?.let { command ->
-                            Button(onClick = { viewModel.run(command) }) {
-                                Text(stringResource(R.string.process_text_retry))
-                            }
-                        }
-                        TextButton(onClick = { viewModel.backToCommands() }) {
-                            Text(stringResource(R.string.process_text_back))
-                        }
+                // Copy is also the fallback when a host refuses to replace the selection.
+                OutlinedButton(onClick = { onCopy(state.result) }) {
+                    Text(stringResource(R.string.process_text_copy))
+                }
+                TextButton(onClick = viewModel::backToCommands) {
+                    Text(stringResource(R.string.process_text_back))
+                }
+            }
+        }
+        is UiState.Error -> {
+            Text(
+                text = state.message,
+                fontSize = 14.sp,
+                color = MaterialTheme.colorScheme.error
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                // Retry only when another request could help.
+                state.retry?.let { command ->
+                    Button(onClick = { viewModel.run(command) }) {
+                        Text(stringResource(R.string.process_text_retry))
                     }
+                }
+                TextButton(onClick = viewModel::backToCommands) {
+                    Text(stringResource(R.string.process_text_back))
                 }
             }
         }

--- a/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextActivity.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextActivity.kt
@@ -6,6 +6,7 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.os.SystemClock
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -56,6 +57,8 @@ import com.musheer360.swiftslate.ui.theme.SwiftSlateTheme
  */
 class ProcessTextActivity : ComponentActivity() {
 
+    private var resultDelivered = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -82,7 +85,7 @@ class ProcessTextActivity : ComponentActivity() {
             SwiftSlateTheme {
                 ProcessTextSheet(
                     viewModel = viewModel(factory = factoryFor(application, selection)),
-                    onInsert = { text -> insertAndFinish(text) },
+                    onInsert = { text -> replaceAndFinish(selection.text, text) },
                     onCopy = { text -> copyAndFinish(text) },
                     onDismiss = { finish() }
                 )
@@ -94,8 +97,19 @@ class ProcessTextActivity : ComponentActivity() {
      * Hands the result back for the host to substitute into the selection. Whether it actually
      * does is the host's choice — Copy is always offered as the manual fallback.
      */
-    private fun insertAndFinish(text: String) {
-        setResult(RESULT_OK, Intent().putExtra(Intent.EXTRA_PROCESS_TEXT, text))
+    private fun replaceAndFinish(original: String, replacement: String) {
+        if (resultDelivered) return
+        resultDelivered = true
+        ProcessTextReplacementBridge.prepare(
+            original = original,
+            replacement = replacement,
+            sourcePackage = callingPackage,
+            now = SystemClock.elapsedRealtime()
+        )
+        setResult(
+            RESULT_OK,
+            Intent().putExtra(Intent.EXTRA_PROCESS_TEXT, replacement)
+        )
         finish()
     }
 
@@ -158,7 +172,7 @@ private fun ProcessTextSheet(
                     ) {
                         if (s.canInsert) {
                             Button(onClick = { onInsert(s.result) }) {
-                                Text(stringResource(R.string.process_text_insert))
+                                Text(stringResource(R.string.process_text_replace))
                             }
                         }
                         // Always offered, editable or not: it is also the recovery path when a

--- a/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextActivity.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextActivity.kt
@@ -9,11 +9,6 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.AnimatedContentTransitionScope
-import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -36,7 +31,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -44,7 +39,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
@@ -77,7 +71,7 @@ class ProcessTextActivity : ComponentActivity() {
             // Finish with a short toast rather than showing an empty sheet.
             val message = when ((e as? RejectedSelectionException)?.rejection) {
                 Rejection.TooLong -> getString(R.string.error_input_too_long)
-                Rejection.Missing, null -> getString(R.string.process_text_no_selection)
+                else -> getString(R.string.process_text_no_selection)
             }
             Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
             finish()
@@ -125,19 +119,10 @@ private fun ProcessTextSheet(
     onCopy: (String) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val state by viewModel.uiState.collectAsState()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
-    LaunchedEffect(state) {
-        val preview = state as? UiState.Preview ?: return@LaunchedEffect
-        if (preview.canInsert) onInsert(preview.result)
-    }
-
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-        containerColor = MaterialTheme.colorScheme.background
-    ) {
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Column(modifier = Modifier.padding(horizontal = 20.dp).padding(bottom = 24.dp)) {
             Text(
                 text = stringResource(R.string.process_text_title),
@@ -147,89 +132,65 @@ private fun ProcessTextSheet(
                 modifier = Modifier.padding(bottom = 12.dp)
             )
 
-            AnimatedContent(
-                targetState = state,
-                transitionSpec = {
-                    val direction = if (targetState is UiState.CommandList) {
-                        AnimatedContentTransitionScope.SlideDirection.Down
-                    } else {
-                        AnimatedContentTransitionScope.SlideDirection.Up
-                    }
-                    slideIntoContainer(direction, tween(250, easing = FastOutSlowInEasing)) togetherWith
-                        slideOutOfContainer(direction, tween(250, easing = FastOutSlowInEasing))
-                },
-                contentKey = { it::class },
-                label = "process_text_transition"
-            ) { currentState ->
-                ProcessTextContent(currentState, viewModel, onInsert, onCopy)
-            }
-        }
-    }
-}
-
-@Composable
-private fun ProcessTextContent(
-    state: UiState,
-    viewModel: ProcessTextViewModel,
-    onInsert: (String) -> Unit,
-    onCopy: (String) -> Unit
-) {
-    when (state) {
-        is UiState.CommandList -> CommandRows(state.commands) { viewModel.run(it) }
-        is UiState.Loading -> Row(verticalAlignment = Alignment.CenterVertically) {
-            CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
-            Spacer(Modifier.width(12.dp))
-            Text(
-                text = state.command.trigger,
-                fontSize = 14.sp,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-        is UiState.Preview -> {
-            Text(
-                text = state.result,
-                fontSize = 15.sp,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier
-                    .heightIn(max = 240.dp)
-                    .verticalScroll(rememberScrollState())
-            )
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                if (state.canInsert) {
-                    Button(onClick = { onInsert(state.result) }) {
-                        Text(stringResource(R.string.process_text_insert))
+            when (val s = state) {
+                is UiState.CommandList -> CommandRows(s.commands) { viewModel.run(it) }
+                is UiState.Loading -> Row(verticalAlignment = Alignment.CenterVertically) {
+                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                    Spacer(Modifier.width(12.dp))
+                    Text(
+                        text = s.command.trigger,
+                        fontSize = 14.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                is UiState.Preview -> {
+                    Text(
+                        text = s.result,
+                        fontSize = 15.sp,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier
+                            .heightIn(max = 240.dp)
+                            .verticalScroll(rememberScrollState())
+                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        if (s.canInsert) {
+                            Button(onClick = { onInsert(s.result) }) {
+                                Text(stringResource(R.string.process_text_insert))
+                            }
+                        }
+                        // Always offered, editable or not: it is also the recovery path when a
+                        // host silently declines the replacement.
+                        OutlinedButton(onClick = { onCopy(s.result) }) {
+                            Text(stringResource(R.string.process_text_copy))
+                        }
+                        TextButton(onClick = { viewModel.backToCommands() }) {
+                            Text(stringResource(R.string.process_text_back))
+                        }
                     }
                 }
-                // Copy is also the fallback when a host refuses to replace the selection.
-                OutlinedButton(onClick = { onCopy(state.result) }) {
-                    Text(stringResource(R.string.process_text_copy))
-                }
-                TextButton(onClick = viewModel::backToCommands) {
-                    Text(stringResource(R.string.process_text_back))
-                }
-            }
-        }
-        is UiState.Error -> {
-            Text(
-                text = state.message,
-                fontSize = 14.sp,
-                color = MaterialTheme.colorScheme.error
-            )
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                // Retry only when another request could help.
-                state.retry?.let { command ->
-                    Button(onClick = { viewModel.run(command) }) {
-                        Text(stringResource(R.string.process_text_retry))
+                is UiState.Error -> {
+                    Text(
+                        text = s.message,
+                        fontSize = 14.sp,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        // Offered only for failures a re-run could actually fix.
+                        s.retry?.let { command ->
+                            Button(onClick = { viewModel.run(command) }) {
+                                Text(stringResource(R.string.process_text_retry))
+                            }
+                        }
+                        TextButton(onClick = { viewModel.backToCommands() }) {
+                            Text(stringResource(R.string.process_text_back))
+                        }
                     }
-                }
-                TextButton(onClick = viewModel::backToCommands) {
-                    Text(stringResource(R.string.process_text_back))
                 }
             }
         }

--- a/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextActivity.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextActivity.kt
@@ -1,0 +1,233 @@
+package com.musheer360.swiftslate.ui.processtext
+
+import android.app.Application
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.musheer360.swiftslate.R
+import com.musheer360.swiftslate.model.Command
+import com.musheer360.swiftslate.ui.components.SlateItemCard
+import com.musheer360.swiftslate.ui.theme.SwiftSlateTheme
+
+/**
+ * Handles ACTION_PROCESS_TEXT: the entry point Android offers in the text-selection popup.
+ * A one-shot dialog activity — no overlay, no new permissions, gone as soon as it finishes.
+ *
+ * Owns everything Activity-scoped (clipboard, setResult/finish); the request policy lives in
+ * [ProcessTextViewModel] and the pure modules behind it.
+ */
+class ProcessTextActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // PROCESS_TEXT activities are always launched fresh with their Intent, so the selection
+        // itself never needs saving across process death.
+        val parsed = ProcessTextInput.parseSelection(
+            rawText = intent?.getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT),
+            readOnlyExtra = intent?.extras
+                ?.takeIf { it.containsKey(Intent.EXTRA_PROCESS_TEXT_READONLY) }
+                ?.getBoolean(Intent.EXTRA_PROCESS_TEXT_READONLY)
+        )
+        val selection = parsed.getOrElse { e ->
+            // Finish with a short toast rather than showing an empty sheet.
+            val message = when ((e as? RejectedSelectionException)?.rejection) {
+                Rejection.TooLong -> getString(R.string.error_input_too_long)
+                else -> getString(R.string.process_text_no_selection)
+            }
+            Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+            finish()
+            return
+        }
+
+        setContent {
+            SwiftSlateTheme {
+                ProcessTextSheet(
+                    viewModel = viewModel(factory = factoryFor(application, selection)),
+                    onInsert = { text -> insertAndFinish(text) },
+                    onCopy = { text -> copyAndFinish(text) },
+                    onDismiss = { finish() }
+                )
+            }
+        }
+    }
+
+    /**
+     * Hands the result back for the host to substitute into the selection. Whether it actually
+     * does is the host's choice — Copy is always offered as the manual fallback.
+     */
+    private fun insertAndFinish(text: String) {
+        setResult(RESULT_OK, Intent().putExtra(Intent.EXTRA_PROCESS_TEXT, text))
+        finish()
+    }
+
+    private fun copyAndFinish(text: String) {
+        val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+        clipboard?.setPrimaryClip(ClipData.newPlainText("SwiftSlate", text))
+        Toast.makeText(this, getString(R.string.process_text_copied), Toast.LENGTH_SHORT).show()
+        finish()
+    }
+
+    private fun factoryFor(app: Application, selection: Selection) = viewModelFactory {
+        initializer { ProcessTextViewModel(app, selection) }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ProcessTextSheet(
+    viewModel: ProcessTextViewModel,
+    onInsert: (String) -> Unit,
+    onCopy: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val state by viewModel.uiState.collectAsState()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(modifier = Modifier.padding(horizontal = 20.dp).padding(bottom = 24.dp)) {
+            Text(
+                text = stringResource(R.string.process_text_title),
+                fontSize = 17.sp,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(bottom = 12.dp)
+            )
+
+            when (val s = state) {
+                is UiState.CommandList -> CommandRows(s.commands) { viewModel.run(it) }
+                is UiState.Loading -> Row(verticalAlignment = Alignment.CenterVertically) {
+                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                    Spacer(Modifier.width(12.dp))
+                    Text(
+                        text = s.command.trigger,
+                        fontSize = 14.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                is UiState.Preview -> {
+                    Text(
+                        text = s.result,
+                        fontSize = 15.sp,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier
+                            .heightIn(max = 240.dp)
+                            .verticalScroll(rememberScrollState())
+                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        if (s.canInsert) {
+                            Button(onClick = { onInsert(s.result) }) {
+                                Text(stringResource(R.string.process_text_insert))
+                            }
+                        }
+                        // Always offered, editable or not: it is also the recovery path when a
+                        // host silently declines the replacement.
+                        OutlinedButton(onClick = { onCopy(s.result) }) {
+                            Text(stringResource(R.string.process_text_copy))
+                        }
+                        TextButton(onClick = { viewModel.backToCommands() }) {
+                            Text(stringResource(R.string.process_text_back))
+                        }
+                    }
+                }
+                is UiState.Error -> {
+                    Text(
+                        text = s.message,
+                        fontSize = 14.sp,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        // Offered only for failures a re-run could actually fix.
+                        s.retry?.let { command ->
+                            Button(onClick = { viewModel.run(command) }) {
+                                Text(stringResource(R.string.process_text_retry))
+                            }
+                        }
+                        TextButton(onClick = { viewModel.backToCommands() }) {
+                            Text(stringResource(R.string.process_text_back))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CommandRows(commands: List<Command>, onPick: (Command) -> Unit) {
+    if (commands.isEmpty()) {
+        Text(
+            text = stringResource(R.string.process_text_no_commands),
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        return
+    }
+    Column(
+        modifier = Modifier
+            .heightIn(max = 380.dp)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        commands.forEach { command ->
+            // 48dp minimum touch target (Material3).
+            SlateItemCard(
+                modifier = Modifier
+                    .heightIn(min = 48.dp)
+                    .clickable { onPick(command) }
+            ) {
+                Text(
+                    text = command.trigger,
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextActivity.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextActivity.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -126,6 +127,11 @@ private fun ProcessTextSheet(
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    LaunchedEffect(state) {
+        val preview = state as? UiState.Preview ?: return@LaunchedEffect
+        if (preview.canInsert) onInsert(preview.result)
+    }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,

--- a/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextInput.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextInput.kt
@@ -58,7 +58,7 @@ object ProcessTextInput {
         return Result.success(Selection(text = s, readOnly = readOnlyExtra ?: true))
     }
 
-    /** Ignore selections made only of invisible text, including bidi overrides such as RTLO. */
+    /** Zero-width and bidi/format characters: visually nothing, so not meaningful content. */
     private fun isInvisible(c: Char): Boolean =
         c == ZERO_WIDTH_SPACE || c == ZWNJ || c == ZWJ || c == WORD_JOINER ||
             c == SOFT_HYPHEN || c == BOM ||

--- a/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextInput.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextInput.kt
@@ -58,7 +58,7 @@ object ProcessTextInput {
         return Result.success(Selection(text = s, readOnly = readOnlyExtra ?: true))
     }
 
-    /** Zero-width and bidi/format characters: visually nothing, so not meaningful content. */
+    /** Ignore selections made only of invisible text, including bidi overrides such as RTLO. */
     private fun isInvisible(c: Char): Boolean =
         c == ZERO_WIDTH_SPACE || c == ZWNJ || c == ZWJ || c == WORD_JOINER ||
             c == SOFT_HYPHEN || c == BOM ||

--- a/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextInput.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextInput.kt
@@ -13,12 +13,20 @@ class RejectedSelectionException(val rejection: Rejection) : Exception()
 
 /**
  * Parses and validates the two extras an ACTION_PROCESS_TEXT intent delivers. Pure: its
- * entire input is those two values — no Context, no prefs, no CommandManager.
+ * entire input is those two values -- no Context, no prefs, no CommandManager.
  */
 object ProcessTextInput {
 
-    /** Client-side sanity bound in UTF-16 code units — what the payload actually costs. */
+    /** Client-side sanity bound in UTF-16 code units -- what the payload actually costs. */
     const val MAX_CHARS = 20_000
+
+    // Invisible characters as \u escapes so none sit literally (as raw bytes) in this file.
+    private const val BOM = '\uFEFF' // zero-width no-break space; some hosts prepend it
+    private const val ZERO_WIDTH_SPACE = '\u200B'
+    private const val ZWNJ = '\u200C'
+    private const val ZWJ = '\u200D'
+    private const val WORD_JOINER = '\u2060'
+    private const val SOFT_HYPHEN = '\u00AD'
 
     /**
      * @param rawText Intent.EXTRA_PROCESS_TEXT as delivered (may be null, often a Spanned).
@@ -35,8 +43,7 @@ object ProcessTextInput {
         // Flatten once: EXTRA_PROCESS_TEXT frequently arrives as a Spanned, and carrying
         // host-specific span classes into equality checks or the model prompt helps nobody.
         var s = rawText.toString()
-        // Some hosts prepend a BOM / zero-width no-break space.
-        s = s.removePrefix("﻿")
+        s = s.removePrefix(BOM.toString())
         // Normalize line endings so payloads are consistent across hosts and the model does
         // not appear to have "changed" text merely by echoing \n back.
         s = s.replace("\r\n", "\n").replace('\r', '\n')
@@ -53,8 +60,8 @@ object ProcessTextInput {
 
     /** Zero-width and bidi/format characters: visually nothing, so not meaningful content. */
     private fun isInvisible(c: Char): Boolean =
-        c == '​' || c == '‌' || c == '‍' || c == '⁠' ||
-            c == '­' || c == '﻿' ||
+        c == ZERO_WIDTH_SPACE || c == ZWNJ || c == ZWJ || c == WORD_JOINER ||
+            c == SOFT_HYPHEN || c == BOM ||
             c.category == CharCategory.FORMAT
 
     private fun reject(r: Rejection): Result<Selection> =

--- a/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextInput.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextInput.kt
@@ -1,0 +1,62 @@
+package com.musheer360.swiftslate.ui.processtext
+
+data class Selection(val text: String, val readOnly: Boolean)
+
+sealed interface Rejection {
+    /** Extra absent, or blank/invisible-only after normalization. */
+    data object Missing : Rejection
+    /** Longer than the client-side sanity limit. */
+    data object TooLong : Rejection
+}
+
+class RejectedSelectionException(val rejection: Rejection) : Exception()
+
+/**
+ * Parses and validates the two extras an ACTION_PROCESS_TEXT intent delivers. Pure: its
+ * entire input is those two values — no Context, no prefs, no CommandManager.
+ */
+object ProcessTextInput {
+
+    /** Client-side sanity bound in UTF-16 code units — what the payload actually costs. */
+    const val MAX_CHARS = 20_000
+
+    /**
+     * @param rawText Intent.EXTRA_PROCESS_TEXT as delivered (may be null, often a Spanned).
+     * @param readOnlyExtra EXTRA_PROCESS_TEXT_READONLY; null defaults to read-only, since
+     *   absence signals a host that never opted into in-place editing.
+     */
+    fun parseSelection(
+        rawText: CharSequence?,
+        readOnlyExtra: Boolean?,
+        maxChars: Int = MAX_CHARS
+    ): Result<Selection> {
+        if (rawText == null) return reject(Rejection.Missing)
+
+        // Flatten once: EXTRA_PROCESS_TEXT frequently arrives as a Spanned, and carrying
+        // host-specific span classes into equality checks or the model prompt helps nobody.
+        var s = rawText.toString()
+        // Some hosts prepend a BOM / zero-width no-break space.
+        s = s.removePrefix("﻿")
+        // Normalize line endings so payloads are consistent across hosts and the model does
+        // not appear to have "changed" text merely by echoing \n back.
+        s = s.replace("\r\n", "\n").replace('\r', '\n')
+
+        // Blankness is tested on the trimmed form, but the untrimmed text is what gets sent:
+        // interior newlines and indentation are meaningful content (paragraphs, code blocks),
+        // and the accessibility path does not collapse them either.
+        if (s.trim().all { it.isWhitespace() || isInvisible(it) }) return reject(Rejection.Missing)
+
+        if (s.length > maxChars) return reject(Rejection.TooLong)
+
+        return Result.success(Selection(text = s, readOnly = readOnlyExtra ?: true))
+    }
+
+    /** Zero-width and bidi/format characters: visually nothing, so not meaningful content. */
+    private fun isInvisible(c: Char): Boolean =
+        c == '​' || c == '‌' || c == '‍' || c == '⁠' ||
+            c == '­' || c == '﻿' ||
+            c.category == CharCategory.FORMAT
+
+    private fun reject(r: Rejection): Result<Selection> =
+        Result.failure(RejectedSelectionException(r))
+}

--- a/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextReplacement.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextReplacement.kt
@@ -1,0 +1,80 @@
+package com.musheer360.swiftslate.ui.processtext
+
+import java.util.concurrent.atomic.AtomicReference
+
+internal data class PendingProcessTextReplacement(
+    val original: String,
+    val replacement: String,
+    val sourcePackage: String?,
+    val createdAt: Long
+)
+
+internal sealed interface ProcessTextEdit {
+    data object Unrelated : ProcessTextEdit
+    data object Replaced : ProcessTextEdit
+    data class Appended(val correctedText: String) : ProcessTextEdit
+}
+
+/** One result awaiting application by the app that launched ACTION_PROCESS_TEXT. */
+internal object ProcessTextReplacementBridge {
+    private const val MAX_AGE_MS = 3_000L
+    private val pending = AtomicReference<PendingProcessTextReplacement?>()
+
+    fun prepare(original: String, replacement: String, sourcePackage: String?, now: Long) {
+        pending.set(PendingProcessTextReplacement(original, replacement, sourcePackage, now))
+    }
+
+    fun current(now: Long): PendingProcessTextReplacement? {
+        val request = pending.get() ?: return null
+        if (now - request.createdAt in 0..MAX_AGE_MS) return request
+        pending.compareAndSet(request, null)
+        return null
+    }
+
+    fun consume(request: PendingProcessTextReplacement): Boolean =
+        pending.compareAndSet(request, null)
+}
+
+/**
+ * Distinguishes a proper selection replacement from hosts that append the result after it.
+ * AccessibilityEvent indices and counts are UTF-16 offsets, matching Kotlin String indices.
+ */
+internal fun resolveProcessTextEdit(
+    beforeText: String,
+    afterText: String,
+    fromIndex: Int,
+    removedCount: Int,
+    addedCount: Int,
+    request: PendingProcessTextReplacement
+): ProcessTextEdit {
+    val original = request.original
+    val replacement = request.replacement
+    if (fromIndex < 0 || fromIndex > beforeText.length || addedCount != replacement.length) {
+        return ProcessTextEdit.Unrelated
+    }
+
+    if (removedCount < 0 || fromIndex + removedCount > beforeText.length) {
+        return ProcessTextEdit.Unrelated
+    }
+    val expectedAfter = beforeText.replaceRange(
+        fromIndex,
+        fromIndex + removedCount,
+        replacement
+    )
+    if (expectedAfter != afterText) return ProcessTextEdit.Unrelated
+
+    if (removedCount == original.length &&
+        beforeText.regionMatches(fromIndex, original, 0, original.length)) {
+        return ProcessTextEdit.Replaced
+    }
+
+    val originalStart = fromIndex - original.length
+    if (removedCount == 0 && originalStart >= 0 &&
+        beforeText.regionMatches(originalStart, original, 0, original.length)) {
+        return ProcessTextEdit.Appended(
+            beforeText.replaceRange(originalStart, fromIndex, replacement)
+        )
+    }
+
+    return ProcessTextEdit.Unrelated
+}

--- a/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextViewModel.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextViewModel.kt
@@ -4,10 +4,10 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.musheer360.swiftslate.R
+import com.musheer360.swiftslate.SwiftSlateApp
 import com.musheer360.swiftslate.api.GeminiClient
 import com.musheer360.swiftslate.api.OpenAICompatibleClient
 import com.musheer360.swiftslate.manager.CommandManager
-import com.musheer360.swiftslate.manager.KeyManager
 import com.musheer360.swiftslate.manager.StatsManager
 import com.musheer360.swiftslate.model.Command
 import com.musheer360.swiftslate.model.CommandType
@@ -47,7 +47,9 @@ class ProcessTextViewModel(
     // All lazy: each constructor touches SharedPreferences (and, for KeyManager, the
     // Keystore), and this class is built on the main thread. First touch of each happens
     // inside a Dispatchers.IO block.
-    private val keyManager by lazy { KeyManager(app) }
+    // KeyManager is the process-wide one: benched keys have to be shared with the accessibility
+    // service, or this flow re-tries keys that one already knows are rate-limited or invalid.
+    private val keyManager by lazy { (app as SwiftSlateApp).keyManager }
     private val commandManager by lazy { CommandManager(app) }
     private val statsManager by lazy { StatsManager(app) }
     private val geminiClient by lazy { GeminiClient() }

--- a/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextViewModel.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/processtext/ProcessTextViewModel.kt
@@ -1,0 +1,132 @@
+package com.musheer360.swiftslate.ui.processtext
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.musheer360.swiftslate.R
+import com.musheer360.swiftslate.api.GeminiClient
+import com.musheer360.swiftslate.api.OpenAICompatibleClient
+import com.musheer360.swiftslate.manager.CommandManager
+import com.musheer360.swiftslate.manager.KeyManager
+import com.musheer360.swiftslate.manager.StatsManager
+import com.musheer360.swiftslate.model.Command
+import com.musheer360.swiftslate.model.CommandType
+import com.musheer360.swiftslate.service.CommandOutcome
+import com.musheer360.swiftslate.service.runTextCommand
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+
+sealed interface UiState {
+    data class CommandList(val commands: List<Command>) : UiState
+    data class Loading(val command: Command) : UiState
+    data class Preview(val result: String, val canInsert: Boolean) : UiState
+    /** [retry] is null for failures that re-running cannot fix (e.g. nothing configured). */
+    data class Error(val message: String, val retry: Command? = null) : UiState
+}
+
+/**
+ * Turns a tapped command into UI state. The request itself is [runTextCommand] — the same
+ * function the accessibility service runs for a typed `?trigger`.
+ */
+class ProcessTextViewModel(
+    app: Application,
+    private val selection: Selection
+) : AndroidViewModel(app) {
+
+    private companion object {
+        const val REQUEST_TIMEOUT_MS = 90_000L
+    }
+
+    // All lazy: each constructor touches SharedPreferences (and, for KeyManager, the
+    // Keystore), and this class is built on the main thread. First touch of each happens
+    // inside a Dispatchers.IO block.
+    private val keyManager by lazy { KeyManager(app) }
+    private val commandManager by lazy { CommandManager(app) }
+    private val statsManager by lazy { StatsManager(app) }
+    private val geminiClient by lazy { GeminiClient() }
+    private val openAIClient by lazy { OpenAICompatibleClient() }
+
+    private val _uiState = MutableStateFlow<UiState>(UiState.CommandList(emptyList()))
+    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+
+    /** Loaded once; the picker returns to this list rather than re-reading it from disk. */
+    private var commands: List<Command> = emptyList()
+
+    /**
+     * Gated synchronously in [run] before any suspension point — two rapid taps must not both
+     * get past it, which a read-then-update on a StateFlow would allow.
+     */
+    private val inFlight = AtomicBoolean(false)
+
+    init {
+        viewModelScope.launch {
+            // SharedPreferences is disk-backed, and viewModelScope runs on
+            // Dispatchers.Main.immediate — never touch it on the main thread.
+            commands = withContext(Dispatchers.IO) {
+                // Built-ins are the clipboard/undo commands, which need the live field the
+                // accessibility service has and this flow does not. Filtered on isBuiltIn, not
+                // on trigger text: the prefix is user-configurable, so matching "?copy" would
+                // silently stop filtering the moment someone changed it.
+                commandManager.getCommands().filterNot { it.isBuiltIn }
+            }
+            _uiState.value = UiState.CommandList(commands)
+        }
+    }
+
+    fun run(command: Command) {
+        if (!inFlight.compareAndSet(false, true)) return
+
+        // A snippet needs no request at all — resolve it without touching the network.
+        if (command.type == CommandType.TEXT_REPLACER) {
+            inFlight.set(false)
+            _uiState.value = UiState.Preview(command.prompt, canInsert = !selection.readOnly)
+            viewModelScope.launch { withContext(Dispatchers.IO) { statsManager.recordUsage(command.trigger) } }
+            return
+        }
+
+        _uiState.value = UiState.Loading(command)
+        viewModelScope.launch {
+            _uiState.value = try {
+                // On IO: KeyManager is Keystore-backed and prefs are disk-backed, both read on
+                // whatever dispatcher calls them (the HTTP clients switch to IO themselves).
+                val outcome = withTimeout(REQUEST_TIMEOUT_MS) {
+                    withContext(Dispatchers.IO) {
+                        runTextCommand(
+                            getApplication<Application>(), keyManager, geminiClient, openAIClient,
+                            command.prompt, selection.text
+                        )
+                    }
+                }
+                when (outcome) {
+                    is CommandOutcome.Success -> {
+                        withContext(Dispatchers.IO) { statsManager.recordUsage(command.trigger) }
+                        UiState.Preview(outcome.text, canInsert = !selection.readOnly)
+                    }
+                    is CommandOutcome.Refusal ->
+                        UiState.Error(string(R.string.error_safety_blocked))
+                    is CommandOutcome.Unavailable -> UiState.Error(outcome.message)
+                    is CommandOutcome.Failure -> UiState.Error(outcome.message, retry = command)
+                }
+            } catch (_: TimeoutCancellationException) {
+                UiState.Error(string(R.string.toast_request_timed_out), retry = command)
+            } finally {
+                inFlight.set(false)
+            }
+        }
+    }
+
+    /** Returns to the picker, e.g. to apply a different command to the same selection. */
+    fun backToCommands() {
+        if (inFlight.get()) return
+        _uiState.value = UiState.CommandList(commands)
+    }
+
+    private fun string(resId: Int) = getApplication<Application>().getString(resId)
+}

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">لم يتم تكوين أي مفاتيح API</string>
     <string name="toast_all_keys_invalid">جميع مفاتيح API غير صالحة. يُرجى التحقق من مفاتيحك</string>
     <string name="toast_request_timed_out">انتهت مهلة الطلب</string>
+    <string name="process_text_title">تطبيق أمر</string>
+    <string name="process_text_insert">إدراج</string>
+    <string name="process_text_copy">نسخ</string>
+    <string name="process_text_back">رجوع</string>
+    <string name="process_text_retry">إعادة المحاولة</string>
+    <string name="process_text_copied">تم النسخ</string>
+    <string name="process_text_no_selection">لم يتم تحديد نص</string>
+    <string name="process_text_no_commands">لا توجد أوامر متاحة. أضف أمرًا في SwiftSlate.</string>
     <string name="toast_restore_failed">تعذّر استعادة النص الأصلي</string>
     <string name="toast_nothing_to_undo">لا يوجد شيء للتراجع عنه</string>
     <string name="toast_undo_failed">تعذّر التراجع</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">جميع مفاتيح API غير صالحة. يُرجى التحقق من مفاتيحك</string>
     <string name="toast_request_timed_out">انتهت مهلة الطلب</string>
     <string name="process_text_title">تطبيق أمر</string>
-    <string name="process_text_insert">إدراج</string>
+    <string name="process_text_replace">استبدال</string>
     <string name="process_text_copy">نسخ</string>
     <string name="process_text_back">رجوع</string>
     <string name="process_text_retry">إعادة المحاولة</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Всички API ключове са невалидни. Моля, проверете ключовете си</string>
     <string name="toast_request_timed_out">Времето за заявката изтече</string>
     <string name="process_text_title">Прилагане на команда</string>
-    <string name="process_text_insert">Вмъкване</string>
+    <string name="process_text_replace">Замяна</string>
     <string name="process_text_copy">Копиране</string>
     <string name="process_text_back">Назад</string>
     <string name="process_text_retry">Повторен опит</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Няма конфигурирани API ключове</string>
     <string name="toast_all_keys_invalid">Всички API ключове са невалидни. Моля, проверете ключовете си</string>
     <string name="toast_request_timed_out">Времето за заявката изтече</string>
+    <string name="process_text_title">Прилагане на команда</string>
+    <string name="process_text_insert">Вмъкване</string>
+    <string name="process_text_copy">Копиране</string>
+    <string name="process_text_back">Назад</string>
+    <string name="process_text_retry">Повторен опит</string>
+    <string name="process_text_copied">Копирано</string>
+    <string name="process_text_no_selection">Няма избран текст</string>
+    <string name="process_text_no_commands">Няма налични команди. Добавете команда в SwiftSlate.</string>
     <string name="toast_restore_failed">Оригиналният текст не можа да бъде възстановен</string>
     <string name="toast_nothing_to_undo">Няма нищо за отмяна</string>
     <string name="toast_undo_failed">Отмяната беше неуспешна</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">No hi ha cap clau API configurada</string>
     <string name="toast_all_keys_invalid">Totes les claus API no són vàlides. Comprova les teves claus</string>
     <string name="toast_request_timed_out">La sol·licitud ha esgotat el temps d’espera</string>
+    <string name="process_text_title">Aplica una ordre</string>
+    <string name="process_text_insert">Insereix</string>
+    <string name="process_text_copy">Copia</string>
+    <string name="process_text_back">Enrere</string>
+    <string name="process_text_retry">Torna-ho a provar</string>
+    <string name="process_text_copied">S’ha copiat</string>
+    <string name="process_text_no_selection">No hi ha text seleccionat</string>
+    <string name="process_text_no_commands">No hi ha ordres disponibles. Afegeix-ne una a SwiftSlate.</string>
     <string name="toast_restore_failed">No s’ha pogut restaurar el text original</string>
     <string name="toast_nothing_to_undo">No hi ha res per desfer</string>
     <string name="toast_undo_failed">No s’ha pogut desfer</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Totes les claus API no són vàlides. Comprova les teves claus</string>
     <string name="toast_request_timed_out">La sol·licitud ha esgotat el temps d’espera</string>
     <string name="process_text_title">Aplica una ordre</string>
-    <string name="process_text_insert">Insereix</string>
+    <string name="process_text_replace">Substitueix</string>
     <string name="process_text_copy">Copia</string>
     <string name="process_text_back">Enrere</string>
     <string name="process_text_retry">Torna-ho a provar</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Nejsou nakonfigurovány žádné API klíče</string>
     <string name="toast_all_keys_invalid">Všechny API klíče jsou neplatné. Zkontrolujte prosím své klíče</string>
     <string name="toast_request_timed_out">Časový limit požadavku vypršel</string>
+    <string name="process_text_title">Použít příkaz</string>
+    <string name="process_text_insert">Vložit</string>
+    <string name="process_text_copy">Kopírovat</string>
+    <string name="process_text_back">Zpět</string>
+    <string name="process_text_retry">Zkusit znovu</string>
+    <string name="process_text_copied">Zkopírováno</string>
+    <string name="process_text_no_selection">Není vybrán žádný text</string>
+    <string name="process_text_no_commands">Nejsou k dispozici žádné příkazy. Přidejte jeden ve SwiftSlate.</string>
     <string name="toast_restore_failed">Původní text se nepodařilo obnovit</string>
     <string name="toast_nothing_to_undo">Není co vrátit zpět</string>
     <string name="toast_undo_failed">Nepodařilo se vrátit zpět</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Všechny API klíče jsou neplatné. Zkontrolujte prosím své klíče</string>
     <string name="toast_request_timed_out">Časový limit požadavku vypršel</string>
     <string name="process_text_title">Použít příkaz</string>
-    <string name="process_text_insert">Vložit</string>
+    <string name="process_text_replace">Nahradit</string>
     <string name="process_text_copy">Kopírovat</string>
     <string name="process_text_back">Zpět</string>
     <string name="process_text_retry">Zkusit znovu</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Alle API-nøgler er ugyldige. Tjek venligst dine nøgler</string>
     <string name="toast_request_timed_out">Anmodningen fik timeout</string>
     <string name="process_text_title">Anvend en kommando</string>
-    <string name="process_text_insert">Indsæt</string>
+    <string name="process_text_replace">Erstat</string>
     <string name="process_text_copy">Kopiér</string>
     <string name="process_text_back">Tilbage</string>
     <string name="process_text_retry">Prøv igen</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Ingen API-nøgler konfigureret</string>
     <string name="toast_all_keys_invalid">Alle API-nøgler er ugyldige. Tjek venligst dine nøgler</string>
     <string name="toast_request_timed_out">Anmodningen fik timeout</string>
+    <string name="process_text_title">Anvend en kommando</string>
+    <string name="process_text_insert">Indsæt</string>
+    <string name="process_text_copy">Kopiér</string>
+    <string name="process_text_back">Tilbage</string>
+    <string name="process_text_retry">Prøv igen</string>
+    <string name="process_text_copied">Kopieret</string>
+    <string name="process_text_no_selection">Ingen tekst markeret</string>
+    <string name="process_text_no_commands">Ingen kommandoer tilgængelige. Tilføj en i SwiftSlate.</string>
     <string name="toast_restore_failed">Den oprindelige tekst kunne ikke gendannes</string>
     <string name="toast_nothing_to_undo">Intet at fortryde</string>
     <string name="toast_undo_failed">Kunne ikke fortryde</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -98,6 +98,14 @@
     <string name="toast_no_keys">Keine API-Schlüssel konfiguriert</string>
     <string name="toast_all_keys_invalid">Alle API-Schlüssel sind ungültig. Bitte überprüfe deine Schlüssel</string>
     <string name="toast_request_timed_out">Zeitüberschreitung der Anfrage</string>
+    <string name="process_text_title">Befehl anwenden</string>
+    <string name="process_text_insert">Einfügen</string>
+    <string name="process_text_copy">Kopieren</string>
+    <string name="process_text_back">Zurück</string>
+    <string name="process_text_retry">Erneut versuchen</string>
+    <string name="process_text_copied">Kopiert</string>
+    <string name="process_text_no_selection">Kein Text ausgewählt</string>
+    <string name="process_text_no_commands">Keine Befehle verfügbar. Füge einen in SwiftSlate hinzu.</string>
     <string name="toast_restore_failed">Ursprünglicher Text konnte nicht wiederhergestellt werden</string>
     <string name="toast_nothing_to_undo">Nichts zum Rückgängigmachen</string>
     <string name="toast_undo_failed">Rückgängigmachen fehlgeschlagen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -99,7 +99,7 @@
     <string name="toast_all_keys_invalid">Alle API-Schlüssel sind ungültig. Bitte überprüfe deine Schlüssel</string>
     <string name="toast_request_timed_out">Zeitüberschreitung der Anfrage</string>
     <string name="process_text_title">Befehl anwenden</string>
-    <string name="process_text_insert">Einfügen</string>
+    <string name="process_text_replace">Ersetzen</string>
     <string name="process_text_copy">Kopieren</string>
     <string name="process_text_back">Zurück</string>
     <string name="process_text_retry">Erneut versuchen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Δεν έχουν διαμορφωθεί κλειδιά API</string>
     <string name="toast_all_keys_invalid">Όλα τα κλειδιά API είναι μη έγκυρα. Παρακαλούμε ελέγξτε τα κλειδιά σας</string>
     <string name="toast_request_timed_out">Το αίτημα έληξε</string>
+    <string name="process_text_title">Εφαρμογή εντολής</string>
+    <string name="process_text_insert">Εισαγωγή</string>
+    <string name="process_text_copy">Αντιγραφή</string>
+    <string name="process_text_back">Πίσω</string>
+    <string name="process_text_retry">Δοκιμάστε ξανά</string>
+    <string name="process_text_copied">Αντιγράφηκε</string>
+    <string name="process_text_no_selection">Δεν έχει επιλεγεί κείμενο</string>
+    <string name="process_text_no_commands">Δεν υπάρχουν διαθέσιμες εντολές. Προσθέστε μία στο SwiftSlate.</string>
     <string name="toast_restore_failed">Δεν ήταν δυνατή η επαναφορά του αρχικού κειμένου</string>
     <string name="toast_nothing_to_undo">Δεν υπάρχει τίποτα για αναίρεση</string>
     <string name="toast_undo_failed">Δεν ήταν δυνατή η αναίρεση</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Όλα τα κλειδιά API είναι μη έγκυρα. Παρακαλούμε ελέγξτε τα κλειδιά σας</string>
     <string name="toast_request_timed_out">Το αίτημα έληξε</string>
     <string name="process_text_title">Εφαρμογή εντολής</string>
-    <string name="process_text_insert">Εισαγωγή</string>
+    <string name="process_text_replace">Αντικατάσταση</string>
     <string name="process_text_copy">Αντιγραφή</string>
     <string name="process_text_back">Πίσω</string>
     <string name="process_text_retry">Δοκιμάστε ξανά</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -98,6 +98,14 @@
     <string name="toast_no_keys">No hay claves API configuradas</string>
     <string name="toast_all_keys_invalid">Todas las claves API no son válidas. Comprueba tus claves</string>
     <string name="toast_request_timed_out">Se agotó el tiempo de espera de la solicitud</string>
+    <string name="process_text_title">Aplicar un comando</string>
+    <string name="process_text_insert">Insertar</string>
+    <string name="process_text_copy">Copiar</string>
+    <string name="process_text_back">Atrás</string>
+    <string name="process_text_retry">Reintentar</string>
+    <string name="process_text_copied">Copiado</string>
+    <string name="process_text_no_selection">No hay texto seleccionado</string>
+    <string name="process_text_no_commands">No hay comandos disponibles. Añade uno en SwiftSlate.</string>
     <string name="toast_restore_failed">No se pudo restaurar el texto original</string>
     <string name="toast_nothing_to_undo">Nada que deshacer</string>
     <string name="toast_undo_failed">No se pudo deshacer</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -99,7 +99,7 @@
     <string name="toast_all_keys_invalid">Todas las claves API no son válidas. Comprueba tus claves</string>
     <string name="toast_request_timed_out">Se agotó el tiempo de espera de la solicitud</string>
     <string name="process_text_title">Aplicar un comando</string>
-    <string name="process_text_insert">Insertar</string>
+    <string name="process_text_replace">Reemplazar</string>
     <string name="process_text_copy">Copiar</string>
     <string name="process_text_back">Atrás</string>
     <string name="process_text_retry">Reintentar</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Kõik API võtmed on kehtetud. Palun kontrolli oma võtmeid</string>
     <string name="toast_request_timed_out">Päring aegus</string>
     <string name="process_text_title">Rakenda käsku</string>
-    <string name="process_text_insert">Sisesta</string>
+    <string name="process_text_replace">Asenda</string>
     <string name="process_text_copy">Kopeeri</string>
     <string name="process_text_back">Tagasi</string>
     <string name="process_text_retry">Proovi uuesti</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">API võtmeid pole seadistatud</string>
     <string name="toast_all_keys_invalid">Kõik API võtmed on kehtetud. Palun kontrolli oma võtmeid</string>
     <string name="toast_request_timed_out">Päring aegus</string>
+    <string name="process_text_title">Rakenda käsku</string>
+    <string name="process_text_insert">Sisesta</string>
+    <string name="process_text_copy">Kopeeri</string>
+    <string name="process_text_back">Tagasi</string>
+    <string name="process_text_retry">Proovi uuesti</string>
+    <string name="process_text_copied">Kopeeritud</string>
+    <string name="process_text_no_selection">Teksti pole valitud</string>
+    <string name="process_text_no_commands">Ühtegi käsku pole saadaval. Lisa käsk SwiftSlate’is.</string>
     <string name="toast_restore_failed">Algset teksti ei õnnestunud taastada</string>
     <string name="toast_nothing_to_undo">Pole midagi tagasi võtta</string>
     <string name="toast_undo_failed">Tagasivõtmine ebaõnnestus</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">همه کلیدهای API نامعتبر هستند. لطفاً کلیدهای خود را بررسی کنید</string>
     <string name="toast_request_timed_out">مهلت درخواست به پایان رسید</string>
     <string name="process_text_title">اعمال یک فرمان</string>
-    <string name="process_text_insert">درج</string>
+    <string name="process_text_replace">جایگزینی</string>
     <string name="process_text_copy">کپی</string>
     <string name="process_text_back">بازگشت</string>
     <string name="process_text_retry">تلاش دوباره</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">هیچ کلید API پیکربندی نشده است</string>
     <string name="toast_all_keys_invalid">همه کلیدهای API نامعتبر هستند. لطفاً کلیدهای خود را بررسی کنید</string>
     <string name="toast_request_timed_out">مهلت درخواست به پایان رسید</string>
+    <string name="process_text_title">اعمال یک فرمان</string>
+    <string name="process_text_insert">درج</string>
+    <string name="process_text_copy">کپی</string>
+    <string name="process_text_back">بازگشت</string>
+    <string name="process_text_retry">تلاش دوباره</string>
+    <string name="process_text_copied">کپی شد</string>
+    <string name="process_text_no_selection">هیچ متنی انتخاب نشده است</string>
+    <string name="process_text_no_commands">هیچ فرمانی موجود نیست. یکی در SwiftSlate اضافه کنید.</string>
     <string name="toast_restore_failed">بازیابی متن اصلی انجام نشد</string>
     <string name="toast_nothing_to_undo">چیزی برای واگرد وجود ندارد</string>
     <string name="toast_undo_failed">واگرد انجام نشد</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">API-avaimia ei ole määritetty</string>
     <string name="toast_all_keys_invalid">Kaikki API-avaimet ovat virheellisiä. Tarkista avaimesi</string>
     <string name="toast_request_timed_out">Pyyntö aikakatkaistiin</string>
+    <string name="process_text_title">Käytä komentoa</string>
+    <string name="process_text_insert">Lisää</string>
+    <string name="process_text_copy">Kopioi</string>
+    <string name="process_text_back">Takaisin</string>
+    <string name="process_text_retry">Yritä uudelleen</string>
+    <string name="process_text_copied">Kopioitu</string>
+    <string name="process_text_no_selection">Tekstiä ei ole valittu</string>
+    <string name="process_text_no_commands">Komentoja ei ole käytettävissä. Lisää komento SwiftSlatessa.</string>
     <string name="toast_restore_failed">Alkuperäisen tekstin palauttaminen epäonnistui</string>
     <string name="toast_nothing_to_undo">Ei mitään kumottavaa</string>
     <string name="toast_undo_failed">Kumoaminen epäonnistui</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Kaikki API-avaimet ovat virheellisiä. Tarkista avaimesi</string>
     <string name="toast_request_timed_out">Pyyntö aikakatkaistiin</string>
     <string name="process_text_title">Käytä komentoa</string>
-    <string name="process_text_insert">Lisää</string>
+    <string name="process_text_replace">Korvaa</string>
     <string name="process_text_copy">Kopioi</string>
     <string name="process_text_back">Takaisin</string>
     <string name="process_text_retry">Yritä uudelleen</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -98,6 +98,14 @@
     <string name="toast_no_keys">Aucune clé API configurée</string>
     <string name="toast_all_keys_invalid">Toutes les clés API sont invalides. Veuillez vérifier vos clés</string>
     <string name="toast_request_timed_out">La requête a expiré</string>
+    <string name="process_text_title">Appliquer une commande</string>
+    <string name="process_text_insert">Insérer</string>
+    <string name="process_text_copy">Copier</string>
+    <string name="process_text_back">Retour</string>
+    <string name="process_text_retry">Réessayer</string>
+    <string name="process_text_copied">Copié</string>
+    <string name="process_text_no_selection">Aucun texte sélectionné</string>
+    <string name="process_text_no_commands">Aucune commande disponible. Ajoutez-en une dans SwiftSlate.</string>
     <string name="toast_restore_failed">Impossible de restaurer le texte d\'origine</string>
     <string name="toast_nothing_to_undo">Rien à annuler</string>
     <string name="toast_undo_failed">Impossible d\'annuler</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -99,7 +99,7 @@
     <string name="toast_all_keys_invalid">Toutes les clés API sont invalides. Veuillez vérifier vos clés</string>
     <string name="toast_request_timed_out">La requête a expiré</string>
     <string name="process_text_title">Appliquer une commande</string>
-    <string name="process_text_insert">Insérer</string>
+    <string name="process_text_replace">Remplacer</string>
     <string name="process_text_copy">Copier</string>
     <string name="process_text_back">Retour</string>
     <string name="process_text_retry">Réessayer</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -98,6 +98,14 @@
     <string name="toast_no_keys">कोई API कुंजी कॉन्फ़िगर नहीं है</string>
     <string name="toast_all_keys_invalid">सभी API कुंजियाँ अमान्य हैं। कृपया अपनी कुंजियाँ जाँचें</string>
     <string name="toast_request_timed_out">अनुरोध का समय समाप्त हो गया</string>
+    <string name="process_text_title">कोई कमांड लागू करें</string>
+    <string name="process_text_insert">सम्मिलित करें</string>
+    <string name="process_text_copy">कॉपी करें</string>
+    <string name="process_text_back">वापस</string>
+    <string name="process_text_retry">पुनः प्रयास करें</string>
+    <string name="process_text_copied">कॉपी किया गया</string>
+    <string name="process_text_no_selection">कोई टेक्स्ट चयनित नहीं है</string>
+    <string name="process_text_no_commands">कोई कमांड उपलब्ध नहीं है। SwiftSlate में एक कमांड जोड़ें।</string>
     <string name="toast_restore_failed">मूल टेक्स्ट पुनर्स्थापित नहीं किया जा सका</string>
     <string name="toast_nothing_to_undo">पूर्ववत करने के लिए कुछ नहीं है</string>
     <string name="toast_undo_failed">पूर्ववत नहीं किया जा सका</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -99,7 +99,7 @@
     <string name="toast_all_keys_invalid">सभी API कुंजियाँ अमान्य हैं। कृपया अपनी कुंजियाँ जाँचें</string>
     <string name="toast_request_timed_out">अनुरोध का समय समाप्त हो गया</string>
     <string name="process_text_title">कोई कमांड लागू करें</string>
-    <string name="process_text_insert">सम्मिलित करें</string>
+    <string name="process_text_replace">बदलें</string>
     <string name="process_text_copy">कॉपी करें</string>
     <string name="process_text_back">वापस</string>
     <string name="process_text_retry">पुनः प्रयास करें</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Nema konfiguriranih API ključeva</string>
     <string name="toast_all_keys_invalid">Svi API ključevi su nevažeći. Provjerite svoje ključeve</string>
     <string name="toast_request_timed_out">Isteklo je vrijeme zahtjeva</string>
+    <string name="process_text_title">Primijeni naredbu</string>
+    <string name="process_text_insert">Umetni</string>
+    <string name="process_text_copy">Kopiraj</string>
+    <string name="process_text_back">Natrag</string>
+    <string name="process_text_retry">Pokušaj ponovno</string>
+    <string name="process_text_copied">Kopirano</string>
+    <string name="process_text_no_selection">Nije odabran tekst</string>
+    <string name="process_text_no_commands">Nema dostupnih naredbi. Dodajte jednu u SwiftSlate.</string>
     <string name="toast_restore_failed">Nije moguće vratiti izvorni tekst</string>
     <string name="toast_nothing_to_undo">Ništa za poništiti</string>
     <string name="toast_undo_failed">Poništavanje nije uspjelo</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Svi API ključevi su nevažeći. Provjerite svoje ključeve</string>
     <string name="toast_request_timed_out">Isteklo je vrijeme zahtjeva</string>
     <string name="process_text_title">Primijeni naredbu</string>
-    <string name="process_text_insert">Umetni</string>
+    <string name="process_text_replace">Zamijeni</string>
     <string name="process_text_copy">Kopiraj</string>
     <string name="process_text_back">Natrag</string>
     <string name="process_text_retry">Pokušaj ponovno</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Nincsenek API-kulcsok beállítva</string>
     <string name="toast_all_keys_invalid">Minden API-kulcs érvénytelen. Kérjük, ellenőrizze a kulcsait</string>
     <string name="toast_request_timed_out">A kérés időtúllépést okozott</string>
+    <string name="process_text_title">Parancs alkalmazása</string>
+    <string name="process_text_insert">Beszúrás</string>
+    <string name="process_text_copy">Másolás</string>
+    <string name="process_text_back">Vissza</string>
+    <string name="process_text_retry">Újra</string>
+    <string name="process_text_copied">Másolva</string>
+    <string name="process_text_no_selection">Nincs kijelölt szöveg</string>
+    <string name="process_text_no_commands">Nincs elérhető parancs. Adjon hozzá egyet a SwiftSlate-ben.</string>
     <string name="toast_restore_failed">Nem sikerült visszaállítani az eredeti szöveget</string>
     <string name="toast_nothing_to_undo">Nincs mit visszavonni</string>
     <string name="toast_undo_failed">Nem sikerült a visszavonás</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Minden API-kulcs érvénytelen. Kérjük, ellenőrizze a kulcsait</string>
     <string name="toast_request_timed_out">A kérés időtúllépést okozott</string>
     <string name="process_text_title">Parancs alkalmazása</string>
-    <string name="process_text_insert">Beszúrás</string>
+    <string name="process_text_replace">Csere</string>
     <string name="process_text_copy">Másolás</string>
     <string name="process_text_back">Vissza</string>
     <string name="process_text_retry">Újra</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Tidak ada kunci API yang dikonfigurasi</string>
     <string name="toast_all_keys_invalid">Semua kunci API tidak valid. Harap periksa kunci Anda</string>
     <string name="toast_request_timed_out">Permintaan kehabisan waktu</string>
+    <string name="process_text_title">Terapkan perintah</string>
+    <string name="process_text_insert">Sisipkan</string>
+    <string name="process_text_copy">Salin</string>
+    <string name="process_text_back">Kembali</string>
+    <string name="process_text_retry">Coba lagi</string>
+    <string name="process_text_copied">Disalin</string>
+    <string name="process_text_no_selection">Tidak ada teks yang dipilih</string>
+    <string name="process_text_no_commands">Tidak ada perintah yang tersedia. Tambahkan satu di SwiftSlate.</string>
     <string name="toast_restore_failed">Tidak dapat memulihkan teks asli</string>
     <string name="toast_nothing_to_undo">Tidak ada yang bisa dibatalkan</string>
     <string name="toast_undo_failed">Tidak dapat membatalkan</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Semua kunci API tidak valid. Harap periksa kunci Anda</string>
     <string name="toast_request_timed_out">Permintaan kehabisan waktu</string>
     <string name="process_text_title">Terapkan perintah</string>
-    <string name="process_text_insert">Sisipkan</string>
+    <string name="process_text_replace">Ganti</string>
     <string name="process_text_copy">Salin</string>
     <string name="process_text_back">Kembali</string>
     <string name="process_text_retry">Coba lagi</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Nessuna chiave API configurata</string>
     <string name="toast_all_keys_invalid">Tutte le chiavi API non sono valide. Controlla le tue chiavi</string>
     <string name="toast_request_timed_out">Richiesta scaduta</string>
+    <string name="process_text_title">Applica un comando</string>
+    <string name="process_text_insert">Inserisci</string>
+    <string name="process_text_copy">Copia</string>
+    <string name="process_text_back">Indietro</string>
+    <string name="process_text_retry">Riprova</string>
+    <string name="process_text_copied">Copiato</string>
+    <string name="process_text_no_selection">Nessun testo selezionato</string>
+    <string name="process_text_no_commands">Nessun comando disponibile. Aggiungine uno in SwiftSlate.</string>
     <string name="toast_restore_failed">Impossibile ripristinare il testo originale</string>
     <string name="toast_nothing_to_undo">Niente da annullare</string>
     <string name="toast_undo_failed">Impossibile annullare</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Tutte le chiavi API non sono valide. Controlla le tue chiavi</string>
     <string name="toast_request_timed_out">Richiesta scaduta</string>
     <string name="process_text_title">Applica un comando</string>
-    <string name="process_text_insert">Inserisci</string>
+    <string name="process_text_replace">Sostituisci</string>
     <string name="process_text_copy">Copia</string>
     <string name="process_text_back">Indietro</string>
     <string name="process_text_retry">Riprova</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">לא הוגדרו מפתחות API</string>
     <string name="toast_all_keys_invalid">כל מפתחות ה-API אינם תקינים. אנא בדוק את המפתחות שלך</string>
     <string name="toast_request_timed_out">תם הזמן הקצוב לבקשה</string>
+    <string name="process_text_title">החלת פקודה</string>
+    <string name="process_text_insert">הוספה</string>
+    <string name="process_text_copy">העתקה</string>
+    <string name="process_text_back">חזרה</string>
+    <string name="process_text_retry">ניסיון חוזר</string>
+    <string name="process_text_copied">הועתק</string>
+    <string name="process_text_no_selection">לא נבחר טקסט</string>
+    <string name="process_text_no_commands">אין פקודות זמינות. אפשר להוסיף פקודה ב-SwiftSlate.</string>
     <string name="toast_restore_failed">לא ניתן לשחזר את הטקסט המקורי</string>
     <string name="toast_nothing_to_undo">אין מה לבטל</string>
     <string name="toast_undo_failed">לא ניתן לבטל</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">כל מפתחות ה-API אינם תקינים. אנא בדוק את המפתחות שלך</string>
     <string name="toast_request_timed_out">תם הזמן הקצוב לבקשה</string>
     <string name="process_text_title">החלת פקודה</string>
-    <string name="process_text_insert">הוספה</string>
+    <string name="process_text_replace">החלפה</string>
     <string name="process_text_copy">העתקה</string>
     <string name="process_text_back">חזרה</string>
     <string name="process_text_retry">ניסיון חוזר</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">API キーが設定されていません</string>
     <string name="toast_all_keys_invalid">すべての API キーが無効です。キーを確認してください</string>
     <string name="toast_request_timed_out">リクエストがタイムアウトしました</string>
+    <string name="process_text_title">コマンドを適用</string>
+    <string name="process_text_insert">挿入</string>
+    <string name="process_text_copy">コピー</string>
+    <string name="process_text_back">戻る</string>
+    <string name="process_text_retry">再試行</string>
+    <string name="process_text_copied">コピーしました</string>
+    <string name="process_text_no_selection">テキストが選択されていません</string>
+    <string name="process_text_no_commands">使用できるコマンドがありません。SwiftSlate で追加してください。</string>
     <string name="toast_restore_failed">元のテキストを復元できませんでした</string>
     <string name="toast_nothing_to_undo">元に戻す操作がありません</string>
     <string name="toast_undo_failed">元に戻せませんでした</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">すべての API キーが無効です。キーを確認してください</string>
     <string name="toast_request_timed_out">リクエストがタイムアウトしました</string>
     <string name="process_text_title">コマンドを適用</string>
-    <string name="process_text_insert">挿入</string>
+    <string name="process_text_replace">置換</string>
     <string name="process_text_copy">コピー</string>
     <string name="process_text_back">戻る</string>
     <string name="process_text_retry">再試行</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">모든 API 키가 유효하지 않습니다. 키를 확인하세요</string>
     <string name="toast_request_timed_out">요청 시간이 초과되었습니다</string>
     <string name="process_text_title">명령 적용</string>
-    <string name="process_text_insert">삽입</string>
+    <string name="process_text_replace">바꾸기</string>
     <string name="process_text_copy">복사</string>
     <string name="process_text_back">뒤로</string>
     <string name="process_text_retry">다시 시도</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">구성된 API 키가 없습니다</string>
     <string name="toast_all_keys_invalid">모든 API 키가 유효하지 않습니다. 키를 확인하세요</string>
     <string name="toast_request_timed_out">요청 시간이 초과되었습니다</string>
+    <string name="process_text_title">명령 적용</string>
+    <string name="process_text_insert">삽입</string>
+    <string name="process_text_copy">복사</string>
+    <string name="process_text_back">뒤로</string>
+    <string name="process_text_retry">다시 시도</string>
+    <string name="process_text_copied">복사됨</string>
+    <string name="process_text_no_selection">선택된 텍스트가 없습니다</string>
+    <string name="process_text_no_commands">사용 가능한 명령이 없습니다. SwiftSlate에서 추가하세요.</string>
     <string name="toast_restore_failed">원본 텍스트를 복원할 수 없습니다</string>
     <string name="toast_nothing_to_undo">실행 취소할 항목이 없습니다</string>
     <string name="toast_undo_failed">실행 취소할 수 없습니다</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Visi API raktai negalioja. Patikrinkite savo raktus</string>
     <string name="toast_request_timed_out">Baigėsi užklausos laikas</string>
     <string name="process_text_title">Taikyti komandą</string>
-    <string name="process_text_insert">Įterpti</string>
+    <string name="process_text_replace">Pakeisti</string>
     <string name="process_text_copy">Kopijuoti</string>
     <string name="process_text_back">Atgal</string>
     <string name="process_text_retry">Bandyti dar kartą</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Nesukonfigūruota jokių API raktų</string>
     <string name="toast_all_keys_invalid">Visi API raktai negalioja. Patikrinkite savo raktus</string>
     <string name="toast_request_timed_out">Baigėsi užklausos laikas</string>
+    <string name="process_text_title">Taikyti komandą</string>
+    <string name="process_text_insert">Įterpti</string>
+    <string name="process_text_copy">Kopijuoti</string>
+    <string name="process_text_back">Atgal</string>
+    <string name="process_text_retry">Bandyti dar kartą</string>
+    <string name="process_text_copied">Nukopijuota</string>
+    <string name="process_text_no_selection">Nepasirinktas tekstas</string>
+    <string name="process_text_no_commands">Nėra galimų komandų. Pridėkite komandą programoje „SwiftSlate“.</string>
     <string name="toast_restore_failed">Nepavyko atkurti pradinio teksto</string>
     <string name="toast_nothing_to_undo">Nėra ką anuliuoti</string>
     <string name="toast_undo_failed">Nepavyko anuliuoti</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Visas API atslēgas ir nederīgas. Lūdzu, pārbaudiet savas atslēgas</string>
     <string name="toast_request_timed_out">Pieprasījuma noildze</string>
     <string name="process_text_title">Lietot komandu</string>
-    <string name="process_text_insert">Ievietot</string>
+    <string name="process_text_replace">Aizstāt</string>
     <string name="process_text_copy">Kopēt</string>
     <string name="process_text_back">Atpakaļ</string>
     <string name="process_text_retry">Mēģināt vēlreiz</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Nav konfigurēta neviena API atslēga</string>
     <string name="toast_all_keys_invalid">Visas API atslēgas ir nederīgas. Lūdzu, pārbaudiet savas atslēgas</string>
     <string name="toast_request_timed_out">Pieprasījuma noildze</string>
+    <string name="process_text_title">Lietot komandu</string>
+    <string name="process_text_insert">Ievietot</string>
+    <string name="process_text_copy">Kopēt</string>
+    <string name="process_text_back">Atpakaļ</string>
+    <string name="process_text_retry">Mēģināt vēlreiz</string>
+    <string name="process_text_copied">Nokopēts</string>
+    <string name="process_text_no_selection">Nav atlasīts teksts</string>
+    <string name="process_text_no_commands">Nav pieejamu komandu. Pievienojiet komandu lietotnē SwiftSlate.</string>
     <string name="toast_restore_failed">Nevarēja atjaunot sākotnējo tekstu</string>
     <string name="toast_nothing_to_undo">Nav ko atsaukt</string>
     <string name="toast_undo_failed">Nevarēja atsaukt</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Semua kunci API tidak sah. Sila semak kunci anda</string>
     <string name="toast_request_timed_out">Permintaan tamat masa</string>
     <string name="process_text_title">Gunakan perintah</string>
-    <string name="process_text_insert">Sisip</string>
+    <string name="process_text_replace">Ganti</string>
     <string name="process_text_copy">Salin</string>
     <string name="process_text_back">Kembali</string>
     <string name="process_text_retry">Cuba lagi</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Tiada kunci API dikonfigurasi</string>
     <string name="toast_all_keys_invalid">Semua kunci API tidak sah. Sila semak kunci anda</string>
     <string name="toast_request_timed_out">Permintaan tamat masa</string>
+    <string name="process_text_title">Gunakan perintah</string>
+    <string name="process_text_insert">Sisip</string>
+    <string name="process_text_copy">Salin</string>
+    <string name="process_text_back">Kembali</string>
+    <string name="process_text_retry">Cuba lagi</string>
+    <string name="process_text_copied">Disalin</string>
+    <string name="process_text_no_selection">Tiada teks dipilih</string>
+    <string name="process_text_no_commands">Tiada perintah tersedia. Tambah satu dalam SwiftSlate.</string>
     <string name="toast_restore_failed">Tidak dapat memulihkan teks asal</string>
     <string name="toast_nothing_to_undo">Tiada apa untuk dibuat asal</string>
     <string name="toast_undo_failed">Tidak dapat membuat asal</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Ingen API-nøkler konfigurert</string>
     <string name="toast_all_keys_invalid">Alle API-nøkler er ugyldige. Kontroller nøklene dine</string>
     <string name="toast_request_timed_out">Forespørselen fikk tidsavbrudd</string>
+    <string name="process_text_title">Bruk en kommando</string>
+    <string name="process_text_insert">Sett inn</string>
+    <string name="process_text_copy">Kopier</string>
+    <string name="process_text_back">Tilbake</string>
+    <string name="process_text_retry">Prøv igjen</string>
+    <string name="process_text_copied">Kopiert</string>
+    <string name="process_text_no_selection">Ingen tekst er valgt</string>
+    <string name="process_text_no_commands">Ingen kommandoer er tilgjengelige. Legg til en i SwiftSlate.</string>
     <string name="toast_restore_failed">Kunne ikke gjenopprette den opprinnelige teksten</string>
     <string name="toast_nothing_to_undo">Ingenting å angre</string>
     <string name="toast_undo_failed">Kunne ikke angre</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Alle API-nøkler er ugyldige. Kontroller nøklene dine</string>
     <string name="toast_request_timed_out">Forespørselen fikk tidsavbrudd</string>
     <string name="process_text_title">Bruk en kommando</string>
-    <string name="process_text_insert">Sett inn</string>
+    <string name="process_text_replace">Erstatt</string>
     <string name="process_text_copy">Kopier</string>
     <string name="process_text_back">Tilbake</string>
     <string name="process_text_retry">Prøv igjen</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Alle API-sleutels zijn ongeldig. Controleer uw sleutels</string>
     <string name="toast_request_timed_out">Aanvraag verlopen</string>
     <string name="process_text_title">Opdracht toepassen</string>
-    <string name="process_text_insert">Invoegen</string>
+    <string name="process_text_replace">Vervangen</string>
     <string name="process_text_copy">Kopiëren</string>
     <string name="process_text_back">Terug</string>
     <string name="process_text_retry">Opnieuw proberen</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Geen API-sleutels geconfigureerd</string>
     <string name="toast_all_keys_invalid">Alle API-sleutels zijn ongeldig. Controleer uw sleutels</string>
     <string name="toast_request_timed_out">Aanvraag verlopen</string>
+    <string name="process_text_title">Opdracht toepassen</string>
+    <string name="process_text_insert">Invoegen</string>
+    <string name="process_text_copy">Kopiëren</string>
+    <string name="process_text_back">Terug</string>
+    <string name="process_text_retry">Opnieuw proberen</string>
+    <string name="process_text_copied">Gekopieerd</string>
+    <string name="process_text_no_selection">Geen tekst geselecteerd</string>
+    <string name="process_text_no_commands">Geen opdrachten beschikbaar. Voeg er een toe in SwiftSlate.</string>
     <string name="toast_restore_failed">Kon oorspronkelijke tekst niet herstellen</string>
     <string name="toast_nothing_to_undo">Niets om ongedaan te maken</string>
     <string name="toast_undo_failed">Kon niet ongedaan maken</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Nie skonfigurowano kluczy API</string>
     <string name="toast_all_keys_invalid">Wszystkie klucze API są nieprawidłowe. Sprawdź swoje klucze</string>
     <string name="toast_request_timed_out">Upłynął limit czasu żądania</string>
+    <string name="process_text_title">Zastosuj polecenie</string>
+    <string name="process_text_insert">Wstaw</string>
+    <string name="process_text_copy">Kopiuj</string>
+    <string name="process_text_back">Wstecz</string>
+    <string name="process_text_retry">Spróbuj ponownie</string>
+    <string name="process_text_copied">Skopiowano</string>
+    <string name="process_text_no_selection">Nie wybrano tekstu</string>
+    <string name="process_text_no_commands">Brak dostępnych poleceń. Dodaj polecenie w SwiftSlate.</string>
     <string name="toast_restore_failed">Nie udało się przywrócić oryginalnego tekstu</string>
     <string name="toast_nothing_to_undo">Nie ma nic do cofnięcia</string>
     <string name="toast_undo_failed">Nie udało się cofnąć</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Wszystkie klucze API są nieprawidłowe. Sprawdź swoje klucze</string>
     <string name="toast_request_timed_out">Upłynął limit czasu żądania</string>
     <string name="process_text_title">Zastosuj polecenie</string>
-    <string name="process_text_insert">Wstaw</string>
+    <string name="process_text_replace">Zastąp</string>
     <string name="process_text_copy">Kopiuj</string>
     <string name="process_text_back">Wstecz</string>
     <string name="process_text_retry">Spróbuj ponownie</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -98,6 +98,14 @@
     <string name="toast_no_keys">Nenhuma chave API configurada</string>
     <string name="toast_all_keys_invalid">Todas as chaves API são inválidas. Verifique suas chaves</string>
     <string name="toast_request_timed_out">A solicitação expirou</string>
+    <string name="process_text_title">Aplicar um comando</string>
+    <string name="process_text_insert">Inserir</string>
+    <string name="process_text_copy">Copiar</string>
+    <string name="process_text_back">Voltar</string>
+    <string name="process_text_retry">Tentar novamente</string>
+    <string name="process_text_copied">Copiado</string>
+    <string name="process_text_no_selection">Nenhum texto selecionado</string>
+    <string name="process_text_no_commands">Não há comandos disponíveis. Adicione um no SwiftSlate.</string>
     <string name="toast_restore_failed">Não foi possível restaurar o texto original</string>
     <string name="toast_nothing_to_undo">Nada para desfazer</string>
     <string name="toast_undo_failed">Não foi possível desfazer</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -99,7 +99,7 @@
     <string name="toast_all_keys_invalid">Todas as chaves API são inválidas. Verifique suas chaves</string>
     <string name="toast_request_timed_out">A solicitação expirou</string>
     <string name="process_text_title">Aplicar um comando</string>
-    <string name="process_text_insert">Inserir</string>
+    <string name="process_text_replace">Substituir</string>
     <string name="process_text_copy">Copiar</string>
     <string name="process_text_back">Voltar</string>
     <string name="process_text_retry">Tentar novamente</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Nenhuma chave API configurada</string>
     <string name="toast_all_keys_invalid">Todas as chaves API são inválidas. Verifique as suas chaves</string>
     <string name="toast_request_timed_out">O pedido excedeu o tempo limite</string>
+    <string name="process_text_title">Aplicar um comando</string>
+    <string name="process_text_insert">Inserir</string>
+    <string name="process_text_copy">Copiar</string>
+    <string name="process_text_back">Voltar</string>
+    <string name="process_text_retry">Tentar novamente</string>
+    <string name="process_text_copied">Copiado</string>
+    <string name="process_text_no_selection">Nenhum texto selecionado</string>
+    <string name="process_text_no_commands">Não há comandos disponíveis. Adicione um no SwiftSlate.</string>
     <string name="toast_restore_failed">Não foi possível restaurar o texto original</string>
     <string name="toast_nothing_to_undo">Nada para desfazer</string>
     <string name="toast_undo_failed">Não foi possível desfazer</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Todas as chaves API são inválidas. Verifique as suas chaves</string>
     <string name="toast_request_timed_out">O pedido excedeu o tempo limite</string>
     <string name="process_text_title">Aplicar um comando</string>
-    <string name="process_text_insert">Inserir</string>
+    <string name="process_text_replace">Substituir</string>
     <string name="process_text_copy">Copiar</string>
     <string name="process_text_back">Voltar</string>
     <string name="process_text_retry">Tentar novamente</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Nicio cheie API configurată</string>
     <string name="toast_all_keys_invalid">Toate cheile API sunt invalide. Verifică-ți cheile</string>
     <string name="toast_request_timed_out">Solicitarea a expirat</string>
+    <string name="process_text_title">Aplică o comandă</string>
+    <string name="process_text_insert">Inserează</string>
+    <string name="process_text_copy">Copiază</string>
+    <string name="process_text_back">Înapoi</string>
+    <string name="process_text_retry">Încearcă din nou</string>
+    <string name="process_text_copied">Copiat</string>
+    <string name="process_text_no_selection">Niciun text selectat</string>
+    <string name="process_text_no_commands">Nu există comenzi disponibile. Adaugă una în SwiftSlate.</string>
     <string name="toast_restore_failed">Textul original nu a putut fi restaurat</string>
     <string name="toast_nothing_to_undo">Nimic de anulat</string>
     <string name="toast_undo_failed">Anularea nu a reușit</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Toate cheile API sunt invalide. Verifică-ți cheile</string>
     <string name="toast_request_timed_out">Solicitarea a expirat</string>
     <string name="process_text_title">Aplică o comandă</string>
-    <string name="process_text_insert">Inserează</string>
+    <string name="process_text_replace">Înlocuiește</string>
     <string name="process_text_copy">Copiază</string>
     <string name="process_text_back">Înapoi</string>
     <string name="process_text_retry">Încearcă din nou</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Все ключи API недействительны. Проверьте свои ключи</string>
     <string name="toast_request_timed_out">Время ожидания запроса истекло</string>
     <string name="process_text_title">Применить команду</string>
-    <string name="process_text_insert">Вставить</string>
+    <string name="process_text_replace">Заменить</string>
     <string name="process_text_copy">Копировать</string>
     <string name="process_text_back">Назад</string>
     <string name="process_text_retry">Повторить</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Ключи API не настроены</string>
     <string name="toast_all_keys_invalid">Все ключи API недействительны. Проверьте свои ключи</string>
     <string name="toast_request_timed_out">Время ожидания запроса истекло</string>
+    <string name="process_text_title">Применить команду</string>
+    <string name="process_text_insert">Вставить</string>
+    <string name="process_text_copy">Копировать</string>
+    <string name="process_text_back">Назад</string>
+    <string name="process_text_retry">Повторить</string>
+    <string name="process_text_copied">Скопировано</string>
+    <string name="process_text_no_selection">Текст не выбран</string>
+    <string name="process_text_no_commands">Нет доступных команд. Добавьте команду в SwiftSlate.</string>
     <string name="toast_restore_failed">Не удалось восстановить исходный текст</string>
     <string name="toast_nothing_to_undo">Нечего отменять</string>
     <string name="toast_undo_failed">Не удалось отменить</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Všetky kľúče API sú neplatné. Skontrolujte svoje kľúče</string>
     <string name="toast_request_timed_out">Vypršal časový limit požiadavky</string>
     <string name="process_text_title">Použiť príkaz</string>
-    <string name="process_text_insert">Vložiť</string>
+    <string name="process_text_replace">Nahradiť</string>
     <string name="process_text_copy">Kopírovať</string>
     <string name="process_text_back">Späť</string>
     <string name="process_text_retry">Skúsiť znova</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Nie sú nakonfigurované žiadne kľúče API</string>
     <string name="toast_all_keys_invalid">Všetky kľúče API sú neplatné. Skontrolujte svoje kľúče</string>
     <string name="toast_request_timed_out">Vypršal časový limit požiadavky</string>
+    <string name="process_text_title">Použiť príkaz</string>
+    <string name="process_text_insert">Vložiť</string>
+    <string name="process_text_copy">Kopírovať</string>
+    <string name="process_text_back">Späť</string>
+    <string name="process_text_retry">Skúsiť znova</string>
+    <string name="process_text_copied">Skopírované</string>
+    <string name="process_text_no_selection">Nie je vybratý žiadny text</string>
+    <string name="process_text_no_commands">Nie sú dostupné žiadne príkazy. Pridajte jeden v SwiftSlate.</string>
     <string name="toast_restore_failed">Pôvodný text sa nepodarilo obnoviť</string>
     <string name="toast_nothing_to_undo">Nie je čo vrátiť späť</string>
     <string name="toast_undo_failed">Nepodarilo sa vrátiť späť</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Vsi ključi API so neveljavni. Preverite svoje ključe</string>
     <string name="toast_request_timed_out">Časovna omejitev zahteve je potekla</string>
     <string name="process_text_title">Uporabi ukaz</string>
-    <string name="process_text_insert">Vstavi</string>
+    <string name="process_text_replace">Zamenjaj</string>
     <string name="process_text_copy">Kopiraj</string>
     <string name="process_text_back">Nazaj</string>
     <string name="process_text_retry">Poskusi znova</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Ni konfiguriranih ključev API</string>
     <string name="toast_all_keys_invalid">Vsi ključi API so neveljavni. Preverite svoje ključe</string>
     <string name="toast_request_timed_out">Časovna omejitev zahteve je potekla</string>
+    <string name="process_text_title">Uporabi ukaz</string>
+    <string name="process_text_insert">Vstavi</string>
+    <string name="process_text_copy">Kopiraj</string>
+    <string name="process_text_back">Nazaj</string>
+    <string name="process_text_retry">Poskusi znova</string>
+    <string name="process_text_copied">Kopirano</string>
+    <string name="process_text_no_selection">Besedilo ni izbrano</string>
+    <string name="process_text_no_commands">Ni razpoložljivih ukazov. Dodajte enega v SwiftSlate.</string>
     <string name="toast_restore_failed">Izvirnega besedila ni bilo mogoče obnoviti</string>
     <string name="toast_nothing_to_undo">Ni ničesar za razveljavitev</string>
     <string name="toast_undo_failed">Razveljavitev ni uspela</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Нема конфигурисаних API кључева</string>
     <string name="toast_all_keys_invalid">Сви API кључеви су неважећи. Проверите своје кључеве</string>
     <string name="toast_request_timed_out">Истекло је време захтева</string>
+    <string name="process_text_title">Примени наредбу</string>
+    <string name="process_text_insert">Уметни</string>
+    <string name="process_text_copy">Копирај</string>
+    <string name="process_text_back">Назад</string>
+    <string name="process_text_retry">Покушај поново</string>
+    <string name="process_text_copied">Копирано</string>
+    <string name="process_text_no_selection">Текст није изабран</string>
+    <string name="process_text_no_commands">Нема доступних наредби. Додајте једну у SwiftSlate.</string>
     <string name="toast_restore_failed">Није могуће вратити оригинални текст</string>
     <string name="toast_nothing_to_undo">Нема ништа за опозивање</string>
     <string name="toast_undo_failed">Опозивање није успело</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Сви API кључеви су неважећи. Проверите своје кључеве</string>
     <string name="toast_request_timed_out">Истекло је време захтева</string>
     <string name="process_text_title">Примени наредбу</string>
-    <string name="process_text_insert">Уметни</string>
+    <string name="process_text_replace">Замени</string>
     <string name="process_text_copy">Копирај</string>
     <string name="process_text_back">Назад</string>
     <string name="process_text_retry">Покушај поново</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">คีย์ API ทั้งหมดไม่ถูกต้อง โปรดตรวจสอบคีย์ของคุณ</string>
     <string name="toast_request_timed_out">คำขอหมดเวลา</string>
     <string name="process_text_title">ใช้คำสั่ง</string>
-    <string name="process_text_insert">แทรก</string>
+    <string name="process_text_replace">แทนที่</string>
     <string name="process_text_copy">คัดลอก</string>
     <string name="process_text_back">กลับ</string>
     <string name="process_text_retry">ลองอีกครั้ง</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">ยังไม่ได้กำหนดค่าคีย์ API</string>
     <string name="toast_all_keys_invalid">คีย์ API ทั้งหมดไม่ถูกต้อง โปรดตรวจสอบคีย์ของคุณ</string>
     <string name="toast_request_timed_out">คำขอหมดเวลา</string>
+    <string name="process_text_title">ใช้คำสั่ง</string>
+    <string name="process_text_insert">แทรก</string>
+    <string name="process_text_copy">คัดลอก</string>
+    <string name="process_text_back">กลับ</string>
+    <string name="process_text_retry">ลองอีกครั้ง</string>
+    <string name="process_text_copied">คัดลอกแล้ว</string>
+    <string name="process_text_no_selection">ไม่ได้เลือกข้อความ</string>
+    <string name="process_text_no_commands">ไม่มีคำสั่งที่ใช้ได้ เพิ่มคำสั่งใน SwiftSlate</string>
     <string name="toast_restore_failed">ไม่สามารถกู้คืนข้อความต้นฉบับได้</string>
     <string name="toast_nothing_to_undo">ไม่มีสิ่งที่จะเลิกทำ</string>
     <string name="toast_undo_failed">ไม่สามารถเลิกทำได้</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Tüm API anahtarları geçersiz. Lütfen anahtarlarınızı kontrol edin</string>
     <string name="toast_request_timed_out">İstek zaman aşımına uğradı</string>
     <string name="process_text_title">Bir komut uygula</string>
-    <string name="process_text_insert">Ekle</string>
+    <string name="process_text_replace">Değiştir</string>
     <string name="process_text_copy">Kopyala</string>
     <string name="process_text_back">Geri</string>
     <string name="process_text_retry">Tekrar dene</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Yapılandırılmış API anahtarı yok</string>
     <string name="toast_all_keys_invalid">Tüm API anahtarları geçersiz. Lütfen anahtarlarınızı kontrol edin</string>
     <string name="toast_request_timed_out">İstek zaman aşımına uğradı</string>
+    <string name="process_text_title">Bir komut uygula</string>
+    <string name="process_text_insert">Ekle</string>
+    <string name="process_text_copy">Kopyala</string>
+    <string name="process_text_back">Geri</string>
+    <string name="process_text_retry">Tekrar dene</string>
+    <string name="process_text_copied">Kopyalandı</string>
+    <string name="process_text_no_selection">Metin seçilmedi</string>
+    <string name="process_text_no_commands">Kullanılabilir komut yok. SwiftSlate\'e bir komut ekleyin.</string>
     <string name="toast_restore_failed">Orijinal metin geri yüklenemedi</string>
     <string name="toast_nothing_to_undo">Geri alınacak bir şey yok</string>
     <string name="toast_undo_failed">Geri alınamadı</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Ключі API не налаштовано</string>
     <string name="toast_all_keys_invalid">Усі ключі API недійсні. Будь ласка, перевірте свої ключі</string>
     <string name="toast_request_timed_out">Час очікування запиту вичерпано</string>
+    <string name="process_text_title">Застосувати команду</string>
+    <string name="process_text_insert">Вставити</string>
+    <string name="process_text_copy">Копіювати</string>
+    <string name="process_text_back">Назад</string>
+    <string name="process_text_retry">Спробувати ще раз</string>
+    <string name="process_text_copied">Скопійовано</string>
+    <string name="process_text_no_selection">Текст не вибрано</string>
+    <string name="process_text_no_commands">Немає доступних команд. Додайте команду в SwiftSlate.</string>
     <string name="toast_restore_failed">Не вдалося відновити оригінальний текст</string>
     <string name="toast_nothing_to_undo">Немає чого скасовувати</string>
     <string name="toast_undo_failed">Не вдалося скасувати</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Усі ключі API недійсні. Будь ласка, перевірте свої ключі</string>
     <string name="toast_request_timed_out">Час очікування запиту вичерпано</string>
     <string name="process_text_title">Застосувати команду</string>
-    <string name="process_text_insert">Вставити</string>
+    <string name="process_text_replace">Замінити</string>
     <string name="process_text_copy">Копіювати</string>
     <string name="process_text_back">Назад</string>
     <string name="process_text_retry">Спробувати ще раз</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">Tất cả khóa API đều không hợp lệ. Vui lòng kiểm tra khóa của bạn</string>
     <string name="toast_request_timed_out">Yêu cầu đã hết thời gian chờ</string>
     <string name="process_text_title">Áp dụng lệnh</string>
-    <string name="process_text_insert">Chèn</string>
+    <string name="process_text_replace">Thay thế</string>
     <string name="process_text_copy">Sao chép</string>
     <string name="process_text_back">Quay lại</string>
     <string name="process_text_retry">Thử lại</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">Chưa cấu hình khóa API nào</string>
     <string name="toast_all_keys_invalid">Tất cả khóa API đều không hợp lệ. Vui lòng kiểm tra khóa của bạn</string>
     <string name="toast_request_timed_out">Yêu cầu đã hết thời gian chờ</string>
+    <string name="process_text_title">Áp dụng lệnh</string>
+    <string name="process_text_insert">Chèn</string>
+    <string name="process_text_copy">Sao chép</string>
+    <string name="process_text_back">Quay lại</string>
+    <string name="process_text_retry">Thử lại</string>
+    <string name="process_text_copied">Đã sao chép</string>
+    <string name="process_text_no_selection">Chưa chọn văn bản</string>
+    <string name="process_text_no_commands">Không có lệnh nào. Hãy thêm một lệnh trong SwiftSlate.</string>
     <string name="toast_restore_failed">Không thể khôi phục văn bản gốc</string>
     <string name="toast_nothing_to_undo">Không có gì để hoàn tác</string>
     <string name="toast_undo_failed">Không thể hoàn tác</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -99,7 +99,7 @@
     <string name="toast_all_keys_invalid">所有 API 密钥均无效。请检查您的密钥</string>
     <string name="toast_request_timed_out">请求超时</string>
     <string name="process_text_title">应用命令</string>
-    <string name="process_text_insert">插入</string>
+    <string name="process_text_replace">替换</string>
     <string name="process_text_copy">复制</string>
     <string name="process_text_back">返回</string>
     <string name="process_text_retry">重试</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -98,6 +98,14 @@
     <string name="toast_no_keys">未配置 API 密钥</string>
     <string name="toast_all_keys_invalid">所有 API 密钥均无效。请检查您的密钥</string>
     <string name="toast_request_timed_out">请求超时</string>
+    <string name="process_text_title">应用命令</string>
+    <string name="process_text_insert">插入</string>
+    <string name="process_text_copy">复制</string>
+    <string name="process_text_back">返回</string>
+    <string name="process_text_retry">重试</string>
+    <string name="process_text_copied">已复制</string>
+    <string name="process_text_no_selection">未选择文本</string>
+    <string name="process_text_no_commands">没有可用命令。请在 SwiftSlate 中添加一个命令。</string>
     <string name="toast_restore_failed">无法恢复原始文本</string>
     <string name="toast_nothing_to_undo">没有可撤销的内容</string>
     <string name="toast_undo_failed">无法撤销</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -99,6 +99,14 @@
     <string name="toast_no_keys">未配置 API 密钥</string>
     <string name="toast_all_keys_invalid">所有 API 密钥均无效。请检查您的密钥</string>
     <string name="toast_request_timed_out">请求超时</string>
+    <string name="process_text_title">应用命令</string>
+    <string name="process_text_insert">插入</string>
+    <string name="process_text_copy">复制</string>
+    <string name="process_text_back">返回</string>
+    <string name="process_text_retry">重试</string>
+    <string name="process_text_copied">已复制</string>
+    <string name="process_text_no_selection">未选择文本</string>
+    <string name="process_text_no_commands">没有可用命令。请在 SwiftSlate 中添加一个命令。</string>
     <string name="toast_restore_failed">无法恢复原始文本</string>
     <string name="toast_nothing_to_undo">没有可撤销的内容</string>
     <string name="toast_undo_failed">无法撤销</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -100,7 +100,7 @@
     <string name="toast_all_keys_invalid">所有 API 密钥均无效。请检查您的密钥</string>
     <string name="toast_request_timed_out">请求超时</string>
     <string name="process_text_title">应用命令</string>
-    <string name="process_text_insert">插入</string>
+    <string name="process_text_replace">替換</string>
     <string name="process_text_copy">复制</string>
     <string name="process_text_back">返回</string>
     <string name="process_text_retry">重试</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,7 +101,7 @@
 
     <!-- Text-selection (PROCESS_TEXT) flow -->
     <string name="process_text_title">Apply a command</string>
-    <string name="process_text_insert">Insert</string>
+    <string name="process_text_replace">Replace</string>
     <string name="process_text_copy">Copy</string>
     <string name="process_text_back">Back</string>
     <string name="process_text_retry">Retry</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,16 @@
     <string name="toast_no_keys">No API keys configured</string>
     <string name="toast_all_keys_invalid">All API keys are invalid. Please check your keys</string>
     <string name="toast_request_timed_out">Request timed out</string>
+
+    <!-- Text-selection (PROCESS_TEXT) flow -->
+    <string name="process_text_title">Apply a command</string>
+    <string name="process_text_insert">Insert</string>
+    <string name="process_text_copy">Copy</string>
+    <string name="process_text_back">Back</string>
+    <string name="process_text_retry">Retry</string>
+    <string name="process_text_copied">Copied</string>
+    <string name="process_text_no_selection">No text selected</string>
+    <string name="process_text_no_commands">No commands available. Add one in SwiftSlate.</string>
     <string name="toast_restore_failed">Could not restore original text</string>
     <string name="toast_nothing_to_undo">Nothing to undo</string>
     <string name="toast_undo_failed">Could not undo</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -5,4 +5,20 @@
         <item name="android:navigationBarColor">#FCFCFC</item>
         <item name="android:windowBackground">#FCFCFC</item>
     </style>
+
+    <!--
+        Translucent host window for the text-selection bottom sheet. Only the window chrome is
+        themed here; the sheet content is Compose and follows light/dark itself, which is why
+        there is no values-night counterpart.
+    -->
+    <style name="Theme.SwiftSlate.Dialog" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowAnimationStyle">@null</item>
+        <!-- ModalBottomSheet draws its own scrim; a window dim on top of it double-darkens. -->
+        <item name="android:backgroundDimEnabled">false</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
 </resources>

--- a/app/src/test/java/com/musheer360/swiftslate/ui/processtext/ProcessTextInputTest.kt
+++ b/app/src/test/java/com/musheer360/swiftslate/ui/processtext/ProcessTextInputTest.kt
@@ -79,4 +79,86 @@ class ProcessTextInputTest {
         val result = ProcessTextInput.parseSelection("  hello  \n  world  ", false)
         assertEquals("  hello  \n  world  ", result.getOrThrow().text)
     }
+
+    // --- The length bound is in UTF-16 code units, not characters ---
+
+    @Test
+    fun parseSelection_counts_astral_characters_as_two_units() {
+        // MAX_CHARS is documented as UTF-16 code units because that is what the payload costs.
+        // An emoji is a surrogate pair, so half as many of them fit as the constant suggests —
+        // switching this to codePointCount() would silently double the largest accepted payload.
+        val atLimit = "😀".repeat(ProcessTextInput.MAX_CHARS / 2)
+        assertEquals(ProcessTextInput.MAX_CHARS, atLimit.length)
+        assertTrue(ProcessTextInput.parseSelection(atLimit, false).isSuccess)
+
+        val overLimit = atLimit + "😀"
+        val ex = assertThrows(RejectedSelectionException::class.java) {
+            ProcessTextInput.parseSelection(overLimit, false).getOrThrow()
+        }
+        assertEquals(Rejection.TooLong, ex.rejection)
+    }
+
+    @Test
+    fun parseSelection_surrogate_pairs_are_not_mistaken_for_invisible_text() {
+        // Surrogates are CharCategory.SURROGATE, not FORMAT — an emoji-only selection is real
+        // content and must not be rejected as blank.
+        val result = ProcessTextInput.parseSelection("😀", false)
+        assertEquals("😀", result.getOrThrow().text)
+    }
+
+    @Test
+    fun parseSelection_honours_an_injected_max() {
+        assertTrue(ProcessTextInput.parseSelection("hello", false, maxChars = 5).isSuccess)
+        val ex = assertThrows(RejectedSelectionException::class.java) {
+            ProcessTextInput.parseSelection("hello", false, maxChars = 4).getOrThrow()
+        }
+        assertEquals(Rejection.TooLong, ex.rejection)
+    }
+
+    // --- Normalization happens before the blank check, and only where it should ---
+
+    @Test
+    fun parseSelection_rejects_text_that_is_blank_only_after_normalization() {
+        // "\r\n" is two characters, so a naive isBlank() on the raw input would pass it through
+        // as content and send a lone newline to the model.
+        val ex = assertThrows(RejectedSelectionException::class.java) {
+            ProcessTextInput.parseSelection("\r\n", false).getOrThrow()
+        }
+        assertEquals(Rejection.Missing, ex.rejection)
+    }
+
+    @Test
+    fun parseSelection_collapses_CRLF_before_bare_CR() {
+        // Order matters: replacing bare \r first would turn "\r\n" into "\n\n" and double every
+        // line break coming from a Windows-style host.
+        val result = ProcessTextInput.parseSelection("a\r\r\nb", false)
+        assertEquals("a\n\nb", result.getOrThrow().text)
+    }
+
+    // Invisible characters stay as \u escapes here for the same reason they do in the class under
+    // test: a literal BOM in a source file trips lint's ByteOrderMark check.
+
+    @Test
+    fun parseSelection_rejects_a_selection_that_is_only_a_BOM() {
+        val ex = assertThrows(RejectedSelectionException::class.java) {
+            ProcessTextInput.parseSelection("\uFEFF", false).getOrThrow()
+        }
+        assertEquals(Rejection.Missing, ex.rejection)
+    }
+
+    @Test
+    fun parseSelection_strips_only_a_leading_BOM_not_an_interior_one() {
+        // An interior U+FEFF is a zero-width no-break space the user actually selected; only the
+        // one at the front is an encoding artefact.
+        val result = ProcessTextInput.parseSelection("a\uFEFFb", false)
+        assertEquals("a\uFEFFb", result.getOrThrow().text)
+    }
+
+    @Test
+    fun parseSelection_does_not_strip_invisible_characters_from_real_text() {
+        // Invisibility decides whether a selection is blank; it is not a sanitizer. The text that
+        // goes to the model is what the user selected, zero-width spaces and all.
+        val withZwsp = "a\u200Bb"
+        assertEquals(withZwsp, ProcessTextInput.parseSelection(withZwsp, false).getOrThrow().text)
+    }
 }

--- a/app/src/test/java/com/musheer360/swiftslate/ui/processtext/ProcessTextInputTest.kt
+++ b/app/src/test/java/com/musheer360/swiftslate/ui/processtext/ProcessTextInputTest.kt
@@ -1,0 +1,82 @@
+package com.musheer360.swiftslate.ui.processtext
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class ProcessTextInputTest {
+
+    @Test
+    fun parseSelection_returns_text_and_readOnly_flag() {
+        val result = ProcessTextInput.parseSelection("hello", false)
+        val selection = result.getOrThrow()
+        assertEquals("hello", selection.text)
+        assertFalse(selection.readOnly)
+    }
+
+    @Test
+    fun parseSelection_defaults_readOnly_to_true_when_null() {
+        val selection = ProcessTextInput.parseSelection("hello", null).getOrThrow()
+        assertTrue(selection.readOnly)
+    }
+
+    @Test
+    fun parseSelection_rejects_null_text() {
+        val ex = assertThrows(RejectedSelectionException::class.java) {
+            ProcessTextInput.parseSelection(null, false).getOrThrow()
+        }
+        assertEquals(Rejection.Missing, ex.rejection)
+    }
+
+    @Test
+    fun parseSelection_rejects_blank_text() {
+        val ex = assertThrows(RejectedSelectionException::class.java) {
+            ProcessTextInput.parseSelection("   ", false).getOrThrow()
+        }
+        assertEquals(Rejection.Missing, ex.rejection)
+    }
+
+    @Test
+    fun parseSelection_rejects_invisible_only_text() {
+        // Zero-width space + bidi format char
+        val invisible = "\u200B\u202D"
+        val ex = assertThrows(RejectedSelectionException::class.java) {
+            ProcessTextInput.parseSelection(invisible, false).getOrThrow()
+        }
+        assertEquals(Rejection.Missing, ex.rejection)
+    }
+
+    @Test
+    fun parseSelection_rejects_text_exceeding_max_chars() {
+        val long = "a".repeat(ProcessTextInput.MAX_CHARS + 1)
+        val ex = assertThrows(RejectedSelectionException::class.java) {
+            ProcessTextInput.parseSelection(long, false).getOrThrow()
+        }
+        assertEquals(Rejection.TooLong, ex.rejection)
+    }
+
+    @Test
+    fun parseSelection_accepts_text_at_exact_max_chars() {
+        val exact = "a".repeat(ProcessTextInput.MAX_CHARS)
+        val result = ProcessTextInput.parseSelection(exact, false)
+        assertTrue(result.isSuccess)
+        assertEquals(ProcessTextInput.MAX_CHARS, result.getOrThrow().text.length)
+    }
+
+    @Test
+    fun parseSelection_strips_BOM_prefix() {
+        val result = ProcessTextInput.parseSelection("\uFEFFhello", false)
+        assertEquals("hello", result.getOrThrow().text)
+    }
+
+    @Test
+    fun parseSelection_normalizes_line_endings() {
+        val result = ProcessTextInput.parseSelection("a\r\nb\rc", false)
+        assertEquals("a\nb\nc", result.getOrThrow().text)
+    }
+
+    @Test
+    fun parseSelection_preserves_interior_whitespace() {
+        val result = ProcessTextInput.parseSelection("  hello  \n  world  ", false)
+        assertEquals("  hello  \n  world  ", result.getOrThrow().text)
+    }
+}

--- a/app/src/test/java/com/musheer360/swiftslate/ui/processtext/ProcessTextReplacementTest.kt
+++ b/app/src/test/java/com/musheer360/swiftslate/ui/processtext/ProcessTextReplacementTest.kt
@@ -1,0 +1,84 @@
+package com.musheer360.swiftslate.ui.processtext
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ProcessTextReplacementTest {
+
+    private val request = PendingProcessTextReplacement(
+        original = "world",
+        replacement = "WORLD",
+        sourcePackage = "example.host",
+        createdAt = 0L
+    )
+
+    @Test
+    fun `corrects a result appended after the original selection`() {
+        val edit = resolveProcessTextEdit(
+            beforeText = "hello world!",
+            afterText = "hello worldWORLD!",
+            fromIndex = 11,
+            removedCount = 0,
+            addedCount = 5,
+            request = request
+        )
+
+        assertEquals(ProcessTextEdit.Appended("hello WORLD!"), edit)
+    }
+
+    @Test
+    fun `accepts a proper selection replacement`() {
+        val edit = resolveProcessTextEdit(
+            beforeText = "hello world!",
+            afterText = "hello WORLD!",
+            fromIndex = 6,
+            removedCount = 5,
+            addedCount = 5,
+            request = request
+        )
+
+        assertEquals(ProcessTextEdit.Replaced, edit)
+    }
+
+    @Test
+    fun `uses the event index when the original occurs more than once`() {
+        val edit = resolveProcessTextEdit(
+            beforeText = "world and world!",
+            afterText = "world and worldWORLD!",
+            fromIndex = 15,
+            removedCount = 0,
+            addedCount = 5,
+            request = request
+        )
+
+        assertEquals(ProcessTextEdit.Appended("world and WORLD!"), edit)
+    }
+
+    @Test
+    fun `ignores an insertion that does not exactly match the result`() {
+        val edit = resolveProcessTextEdit(
+            beforeText = "hello world!",
+            afterText = "hello worldOTHER!",
+            fromIndex = 11,
+            removedCount = 0,
+            addedCount = 5,
+            request = request
+        )
+
+        assertEquals(ProcessTextEdit.Unrelated, edit)
+    }
+
+    @Test
+    fun `ignores an insertion not immediately after the original selection`() {
+        val edit = resolveProcessTextEdit(
+            beforeText = "world says hello!",
+            afterText = "world says helloWORLD!",
+            fromIndex = 16,
+            removedCount = 0,
+            addedCount = 5,
+            request = request
+        )
+
+        assertEquals(ProcessTextEdit.Unrelated, edit)
+    }
+}


### PR DESCRIPTION
## What this adds

A new way to trigger your commands:

1. select text in **any app**
2. **SwiftSlate** in the Copy/Share popup,
3. pick a command
4. get the result back with Insert/Copy.

7. Same commands, same requests, same errors as typing `?trigger` — just reachable without the accessibility service, for people who don't know that convention exists.

No new permissions. It's a one-shot dialog activity (`ProcessTextActivity`) that's gone as soon as it closes.

### The one change to existing code:

I tried to preserve everything that I was able. 

The only touched file is `AssistantService.kt`, and only because I didn't want two copies of the request logic that could drift apart.

`processCommand`'s retry loop (key rotation, rate-limit backoff, invalid-key marking, error messages) moved as-is into a new `runTextCommand()` in `service/CommandRunner.kt`. `AssistantService` calls it and still owns everything about the live text field — spinner, `replaceText`, undo, haptics. The new popup calls the same function and just renders the result in a sheet instead.


Two small, deliberate side effects from the move — neither should be visible to users:
- Structured-output is now disabled at the point the API reports the failure, rather than after the field write succeeds.
- The invalid-key check compares string resource IDs instead of translated strings, so it can't misfire if two error messages happen to read the same in some locale.

## New files

- `service/CommandRunner.kt` — the shared request logic (see above).
- `ui/processtext/ProcessTextActivity.kt` + `ProcessTextViewModel.kt` — the popup UI. Picker → loading → result, nothing else.
- `ui/processtext/ProcessTextInput.kt` — parses/validates what Android hands over (strips BOM, normalizes line endings, rejects blank/oversized selections).
- Manifest entry + a translucent dialog theme + a handful of new strings.

Built-in clipboard/undo commands don't show up in the picker — they need the live field this flow doesn't have.

## Tested locally

- [x] `compileDebugKotlin`, `testDebugUnitTest` (64 tests, 0 failures — existing suite, untouched), `lintDebug`, `assembleDebug` all pass
- [x] Not yet tested on a real device: selecting text elsewhere → popup appears → command runs
- [x] Not yet re-verified on-device: existing `?trigger` flow still behaves the same after the `AssistantService` change
