### PR TITLE
test(ci): verify preview APK job

### DIFF
--- a/app/src/main/java/com/musheer360/swiftslate/model/ProviderType.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/model/ProviderType.kt
@@ -8,3 +8,6 @@ object ProviderType {
     private val VALID = setOf(GEMINI, GROQ, CUSTOM)
     fun sanitize(value: String?): String = if (value in VALID) value!! else GEMINI
 }
+
+// CI verification: confirms the preview APK job produces a side-by-side installable
+// artifact and that pull requests never reach the release path. Branch is throwaway.


### PR DESCRIPTION
Throwaway PR to verify two things end to end:

1. the `preview-apk` job produces a side-by-side installable APK artifact
2. `version`, `build`, `release` and `notify-failure` are all skipped for pull requests

Will be closed without merging.