### PR TITLE
feat(i18n): add Swedish translation

### DIFF
--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SwiftSlate</string>
+    <string name="accessibility_service_label">SwiftSlate-assistent</string>
+    <string name="accessibility_service_desc">Ersätter text med hjälp av AI i hela systemet när du skriver utlösarkommandon.</string>
+
+    <!-- Dashboard -->
+    <string name="dashboard_title">Översikt</string>
+    <string name="service_status_active">Aktiv</string>
+    <string name="service_status_inactive">Inaktiv</string>
+    <string name="service_enable">Aktivera</string>
+    <string name="dashboard_api_keys_title">API-nycklar</string>
+    <string name="dashboard_keys_configured">Konfigurerade nycklar: %1$d</string>
+    <string name="dashboard_add_key_hint">Lägg till en API-nyckel för att komma igång.</string>
+    <string name="dashboard_monthly_requests">Den här månaden</string>
+    <string name="dashboard_favorite_command">Vanligaste kommandot</string>
+    <string name="dashboard_no_data">—</string>
+    <string name="dashboard_last_7_days">Senaste 7 dagarna</string>
+
+    <!-- Keys -->
+    <string name="keys_title">API-nycklar</string>
+    <string name="keys_api_key_label">API-nyckel</string>
+    <string name="keys_testing">Testar…</string>
+    <string name="keys_add_key">Lägg till nyckel</string>
+    <string name="keys_valid_added">Giltig nyckel har lagts till!</string>
+    <string name="keys_already_added">Den här nyckeln har redan lagts till</string>
+    <string name="keys_validation_failed">Valideringen misslyckades</string>
+    <string name="keys_keystore_error">Säker nyckellagring är inte tillgänglig på den här enheten. Nycklar kan inte sparas.</string>
+    <string name="keys_custom_endpoint_required">Ange slutpunktsadressen i Inställningar innan du lägger till en nyckel för den anpassade leverantören</string>
+    <string name="keys_get_api_key">Hämta din API-nyckel för %1$s ↗</string>
+    <string name="keys_empty">Inga API-nycklar har lagts till</string>
+
+    <!-- Commands -->
+    <string name="commands_title">Kommandon</string>
+    <string name="commands_add_custom_title">Lägg till anpassat kommando</string>
+    <string name="commands_trigger_label">Utlösare (t.ex. %1$skod)</string>
+    <string name="commands_prompt_label">Prompt (t.ex. Skriv om som en dikt)</string>
+    <string name="commands_add_command">Lägg till kommando</string>
+    <string name="commands_delete_command">Ta bort</string>
+    <string name="commands_edit_command">Redigera</string>
+    <string name="commands_save_command">Spara kommando</string>
+    <string name="commands_cancel">Avbryt</string>
+    <string name="commands_type_ai">AI</string>
+    <string name="commands_type_replacer">Lokalt</string>
+    <string name="commands_replacement_label">Ersättningstext (t.ex. minadress@example.com)</string>
+    <string name="commands_built_in">Inbyggda</string>
+    <string name="commands_error_prefix">Utlösaren måste börja med \'%1$s\'</string>
+    <string name="commands_error_duplicate">Det finns redan ett kommando med den här utlösaren</string>
+    <string name="commands_error_conflict">Krockar med det befintliga kommandot \'%1$s\' — den ena utlösaren är ett prefix till den andra</string>
+    <string name="commands_error_empty_trigger">Utlösaren måste ha ett namn efter prefixet</string>
+
+    <!-- Settings -->
+    <string name="settings_title">Inställningar</string>
+    <string name="settings_provider_title">Modellleverantör</string>
+    <string name="settings_provider_gemini">Google Gemini</string>
+    <string name="settings_provider_groq">Groq</string>
+    <string name="settings_provider_custom">Anpassad (OpenAI-kompatibel)</string>
+    <string name="settings_model_title">Modell</string>
+    <string name="settings_temperature_title">Temperatur</string>
+    <string name="settings_endpoint_title">Slutpunkt</string>
+    <string name="settings_endpoint_placeholder">https://api.example.com/v1</string>
+    <string name="settings_model_placeholder">gpt-4o, claude-3-haiku osv.</string>
+    <string name="settings_trigger_prefix_desc">Symbol som används före kommandonamn (t.ex. %1$sfix).</string>
+    <string name="settings_prefix_error_length">Måste vara exakt 1 tecken</string>
+    <string name="settings_prefix_error_whitespace">Får inte vara ett blanksteg</string>
+    <string name="settings_prefix_error_alphanumeric">Får inte vara en bokstav eller siffra</string>
+    <string name="settings_endpoint_error_scheme">Måste börja med https://</string>
+    <string name="settings_endpoint_error_spaces">Webbadressen får inte innehålla blanksteg</string>
+
+    <!-- Backup -->
+    <string name="backup_desc">Exportera eller importera dina kommandon som en JSON-fil.</string>
+    <string name="backup_export">Exportera</string>
+    <string name="backup_import">Importera</string>
+    <string name="backup_export_success">Kommandona har exporterats</string>
+    <string name="backup_export_error">Exporten misslyckades</string>
+    <string name="backup_import_success">Kommandona har importerats</string>
+    <string name="backup_import_error">Ogiltig säkerhetskopia</string>
+    <string name="backup_import_confirm">Det här ersätter alla dina befintliga anpassade kommandon. Vill du fortsätta?</string>
+    <string name="backup_import_cancel">Avbryt</string>
+    <string name="settings_check_updates">Sök efter uppdateringar</string>
+    <string name="settings_made_by">Skapad med kärlek av Musheer Alam</string>
+    <string name="settings_sponsor">Sponsra på GitHub</string>
+    <string name="commands_collapse">Dölj</string>
+    <string name="commands_expand">Visa</string>
+    <string name="commands_search_hint">Sök bland kommandon…</string>
+    <string name="commands_search_close">Stäng sökning</string>
+    <string name="commands_search_empty">Inga kommandon hittades</string>
+
+    <!-- Delete confirmation -->
+    <string name="delete_confirm_command_title">Ta bort det här kommandot?</string>
+    <string name="delete_confirm_key_title">Ta bort den här API-nyckeln?</string>
+    <string name="delete_confirm_message">Åtgärden kan inte ångras.</string>
+    <string name="delete_confirm_button">Ta bort</string>
+
+    <!-- Runtime toasts (accessibility service) -->
+    <string name="toast_replace_failed">Det gick inte att ersätta texten</string>
+    <string name="toast_custom_not_configured">Den anpassade leverantören är inte konfigurerad. Ange slutpunkt och modell i Inställningar.</string>
+    <string name="toast_key_rate_limited">API-nyckelns anropsgräns har nåtts. Försök igen om %1$d s</string>
+    <string name="toast_no_keys">Inga API-nycklar har konfigurerats</string>
+    <string name="toast_all_keys_invalid">Alla API-nycklar är ogiltiga. Kontrollera dina nycklar</string>
+    <string name="toast_request_timed_out">Tidsgränsen för begäran överskreds</string>
+
+    <!-- Text-selection (PROCESS_TEXT) flow -->
+    <string name="process_text_title">Tillämpa ett kommando</string>
+    <string name="process_text_replace">Ersätt</string>
+    <string name="process_text_copy">Kopiera</string>
+    <string name="process_text_back">Tillbaka</string>
+    <string name="process_text_retry">Försök igen</string>
+    <string name="process_text_copied">Kopierat</string>
+    <string name="process_text_no_selection">Ingen text har markerats</string>
+    <string name="process_text_no_commands">Inga kommandon är tillgängliga. Lägg till ett i SwiftSlate.</string>
+    <string name="toast_restore_failed">Det gick inte att återställa originaltexten</string>
+    <string name="toast_nothing_to_undo">Det finns inget att ångra</string>
+    <string name="toast_undo_failed">Det gick inte att ångra</string>
+    <string name="toast_nothing_to_copy">Det finns inget att kopiera</string>
+    <string name="toast_copied">Kopierat till urklipp</string>
+    <string name="toast_nothing_to_cut">Det finns inget att klippa ut</string>
+    <string name="toast_cut">Texten har klippts ut till urklipp</string>
+    <string name="toast_clipboard_empty">Urklipp är tomt</string>
+    <string name="toast_clipboard_failed">Urklippsåtgärden misslyckades</string>
+
+    <!-- Runtime error messages (accessibility service) -->
+    <string name="error_no_model_access">Din API-nyckel har inte åtkomst till den här modellen.</string>
+    <string name="error_invalid_key">Ogiltig API-nyckel. Kontrollera nyckeln i Inställningar.</string>
+    <string name="error_invalid_key_with_hint">Ogiltig API-nyckel (%1$s). Kontrollera dina nycklar i Inställningar.</string>
+    <string name="error_rate_limited">Anropsgränsen har nåtts. Försök igen om en stund.</string>
+    <string name="error_model_not_found">Modellen hittades inte. Kontrollera modellvalet i Inställningar.</string>
+    <string name="error_safety_blocked">Svaret blockerades av säkerhetsfilter. Försök formulera om texten.</string>
+    <string name="error_empty_response">Modellen returnerade ett tomt svar. Försök igen.</string>
+    <string name="error_timeout_connection">Tidsgränsen för begäran överskreds. Kontrollera anslutningen.</string>
+    <string name="error_no_internet">Ingen internetanslutning.</string>
+    <string name="error_endpoint_unreachable">Det gick inte att nå API:et. Kontrollera slutpunktsadressen.</string>
+    <string name="error_bad_request">Begäran misslyckades. Kontrollera inställningarna.</string>
+    <string name="error_input_too_long">Texten är för lång för modellens tokenbegränsning per minut. Försök igen med en kortare text.</string>
+    <string name="note_response_truncated">[Obs! Svaret kan vara avkortat]</string>
+    <!-- Update notification (worker) -->
+    <string name="update_channel_name">Appuppdateringar</string>
+    <string name="update_channel_desc">Meddelar när en ny version av SwiftSlate är tillgänglig</string>
+    <string name="update_available_title">SwiftSlate-uppdatering tillgänglig</string>
+    <string name="update_available_text">Tryck för att visa den senaste versionen</string>
+
+</resources>


### PR DESCRIPTION
Add a complete Swedish Android resource file with all 119 base strings. Preserve resource keys, ordering, format placeholders, product names, and technical values so the locale is picked up automatically by the existing derived locale configuration.

Verification:
- XML parse and 119/119 key parity
- Android format-placeholder parity
- ./gradlew lint test assembleDebug
- 152 unit tests passed

## What does this PR do?

<!-- Brief description of the change -->

## Type of change

- [ ] Bug fix (Accessibility Service, API handling, UI)
- [ ] New command (built-in AI or text replacer)
- [ ] New provider integration
- [ ] UI / theme change
- [ ] Translation / localization
- [ ] Refactor (no behavior change)
- [ ] Documentation

## Testing

- [ ] Tested with Accessibility Service enabled on a real device
- [ ] Verified trigger detection still works in WhatsApp / Gmail / Notes
- [ ] Text replacer commands execute instantly (no regressions)
- [ ] AI commands return proper responses with Gemini / Groq
- [ ] Password fields are still ignored
- [ ] If touching `service/CommandRunner.kt` or `ui/processtext/`, tested the text-selection
  popup too (with accessibility enabled and disabled)
- [ ] No new external dependencies added

## Checklist

- [ ] Builds cleanly with `./gradlew assembleDebug`
- [ ] No hardcoded API keys or secrets
- [ ] Follows existing code style (no new linters/formatters)
- [ ] Works on API 23+ (no higher-API-only calls without version checks)
