### PR TITLE
feat(wechat): v1.0.76 WeChat compatibility build

### DIFF
--- a/WECHAT_COMPAT.md
+++ b/WECHAT_COMPAT.md
@@ -1,0 +1,175 @@
+# SwiftSlate: WeChat (com.tencent.mm) Compatibility Patch
+
+**Audience:** upstream SwiftSlate maintainers (and anyone who wants to integrate WeChat
+support). This document explains *why* WeChat breaks SwiftSlate, the minimal fix we
+applied, every file it touches, and how to adopt it upstream.
+
+> Scope: the patch is currently bundled in the `preview` build type only, so it does not
+> affect the stable release. We recommend adopting the same structure (see
+> "Integration for upstream" below).
+>
+> Version: this document tracks the **v1.0.76** codebase (upstream `master` at `cabd098`).
+> Upstream has since adopted the `srcNull` fallback itself (#125), so the fork now only
+> adds: the preview whitelist-name services, the recursive editable-node search refinement,
+> the `SwiftSlateDiag` `Log.e` diagnostics, and the UI hints (see §3).
+
+---
+
+## 1. The problem: WeChat actively sabotages accessibility services
+
+WeChat 8.0.74 (versionCode 3120, and presumably all current versions) contains an
+**anti-accessibility defense** that detects non-whitelisted accessibility services and
+then **wipes (or fakes) the accessibility node tree of the active window**. The visible
+symptoms:
+
+- `rootInActiveWindow` returns a tree whose nodes are empty (`rootCls` reports the real
+  class only for the root; child `EditText` nodes vanish).
+- `TYPE_VIEW_TEXT_CHANGED` events for the chat input either never arrive, or arrive with
+  an empty/`null` source.
+- SwiftSlate cannot read the text, so `?fix` / `?translate` never trigger.
+
+This is **not** FLAG_SECURE: the WeChat window does not set it (verified with
+`dumpsys window`). The empty tree is produced in software, in WeChat's accessibility
+bridge.
+
+### Reverse-engineered mechanics (verified against smali)
+
+| Piece | Location (smali) | Behaviour |
+|---|---|---|
+| Master switch | `AccUtil.smali` — `isAccessibilityEnabled()` | Returns `true` (→ no attack) if **any** of: monkey env, TalkBack touch-explore enabled, a whitelist service is enabled, or the account is server-whitelisted. Otherwise returns `false` → the attack arms. |
+| Whitelist match | `AccExptService.smali` — `checkHasServiceInList()` | Reads `Settings.Secure.enabled_accessibility_services` and checks each enabled service string `package/name` with a **`CharSequence.contains()`** against each whitelist entry. |
+| Whitelist entries | `AccExptServiceKt.smali` (clinit) | Exactly two, hard-coded: `com.google.android.accessibility.selecttospeak.SelectToSpeakService` and `com.dianming.phoneapp.MyAccessibilityService`. |
+| Tree wiping | `base/MapExpandKt.smali` — `clearInfo()`/`toFakeInfo()`; entry `MMAccessibilityDelegateWrap.smali:340` `onInitializeAccessibilityNodeInfo()` | When armed, `needClearNodeInfo()` makes the delegate return without populating the node → empty tree. `needUseFakeInfo()` fabricates dummy text. |
+| Server config | `q15/a.smali` + `AccConfigManager.smali` | Fields like `accinfo_clear_strike`, `accinfo_random_strike`, `intercept_stack`; cached in MMKV, expired periodically. |
+
+**The key insight:** the whitelist match is a **string `contains()` on the service's
+`package/name`** against two hard-coded class names. WeChat does not verify that the
+class actually *belongs* to Google or to Dianming — it only checks the string.
+
+---
+
+## 2. The fix: a no-op service whose class name *is* a whitelist entry
+
+Because the match is `package/name` **contains** a whitelisted FQCN, SwiftSlate can
+declare an accessibility service with a class name exactly equal to one of the two
+whitelist entries. WeChat then sees a "whitelisted" service enabled, `isAccessibilityEnabled()`
+returns `true`, and the tree-wiping attack is never armed. The service itself does
+nothing.
+
+Two such services are declared (one per whitelist entry, for redundancy — if WeChat
+rotates one entry, the other still matches):
+
+- `com.google.android.accessibility.selecttospeak.SelectToSpeakService`
+- `com.dianming.phoneapp.MyAccessibilityService`
+
+Both are no-ops (`onAccessibilityEvent`/`onInterrupt` empty). They exist **only** in the
+`preview` source set, never in the stable build.
+
+**Verified on device (Realme RMX2202, Android 14, no root):** after enabling the
+compatibility service together with SwiftSlate's main service, WeChat's `rootCls`
+reports `android.widget.FrameLayout` again, `TEXT_CHANGED` events fire with a real
+source, text is readable, and `?fix` replacement works end-to-end. Requires **no root**
+— it relies only on the standard accessibility-settings toggles.
+
+---
+
+## 3. File-by-file change list
+
+### New files (preview-only)
+
+| File | Purpose |
+|---|---|
+| `app/src/preview/AndroidManifest.xml` | Registers the two no-op compatibility services (label, `BIND_ACCESSIBILITY_SERVICE` permission, standard a11y meta-data). |
+| `app/src/preview/java/com/google/android/accessibility/selecttospeak/SelectToSpeakService.kt` | No-op `AccessibilityService`; class name matches whitelist entry #1. |
+| `app/src/preview/java/com/dianming/phoneapp/MyAccessibilityService.kt` | No-op `AccessibilityService`; class name matches whitelist entry #2. |
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `app/build.gradle.kts` | `buildConfigField("String", "WHITELIST_SERVICE", ...)`: declared **empty in `defaultConfig`** (so stable builds compile — the field is referenced from main source) and overridden in the `preview` buildType with `"com.dianming.phoneapp.MyAccessibilityService"`. Used by the Dashboard hint so the UI can tell whether the compat service is enabled. |
+| `app/proguard-rules.pro` | `-keep` both no-op service classes' `<init>()` — **R8 must not rename them**, the FQCN *is* the feature. (Class names must survive minification exactly.) Also keeps `Log.e` (it carries `SwiftSlateDiag` diagnostics; `-assumenosideeffects` only strips v/d/i/w). |
+| `gradle.properties` | Fork release pin: `versionName=1.0.76`, `versionCode=227` (overridable with `-PversionName`/`-PversionCode`). |
+| `app/src/preview/res/values/strings.xml` | Labels for the two services (`SwiftSlate 微信适配` / `SwiftSlate 微信适配（备选）`). |
+| `app/src/main/java/.../service/AssistantService.kt` | **(a)** `srcNull` fallback refinement: upstream's #125 fallback used `root.findFocus(FOCUS_INPUT)`, which returns the WebView/container node (not editable) for WebView-based editors. The fork walks the tree for a node that is both **editable and focused** (`findFocusedEditableSource` / `findFocusedEditable`), keeping upstream's throttling + crash hardening. **(b)** Diagnostic `Log.e` output (`SwiftSlateDiag`) on the event pipeline and `replaceText`. **(c)** A `startWindowDump()` debug dump-loop, **disabled** (commented call) — it pokes WeChat's delegate every 3s and made the IME candidate bar jump. |
+| `app/src/main/java/.../ui/DashboardScreen.kt` | WeChat-compat hint card: when the main service is on but the whitelist service is off, show a prompt that both must be enabled (preview builds only; guarded by `BuildConfig.WHITELIST_SERVICE` being non-empty). |
+| `app/src/main/java/.../ui/SettingsScreen.kt` | A permanent "Accessibility" entry row (opens `Settings.ACTION_ACCESSIBILITY_SETTINGS`) placed inside the Backup card so it does not disturb the fixed-height layout of the About card. |
+| `app/src/main/res/values/strings.xml` (+ `values-zh`, `values-zh-rCN`) | New strings: accessibility entry (`settings_accessibility_*`) and Dashboard hint (`dashboard_wechat_hint_*`). |
+
+---
+
+## 4. The srcNull fallback (a genuinely useful side-fix)
+
+While diagnosing, we found that some apps emit `TYPE_VIEW_TEXT_CHANGED` with
+`event.source == null` (custom input pipelines, WebViews, etc.). Previously SwiftSlate
+aborted on those. **Upstream already adopted this fix in #125** (v1.0.76); the fork only
+refines it: upstream's version calls `root.findFocus(AccessibilityNodeInfo.FOCUS_INPUT)`,
+which for WebView-based editors returns the WebView *container* (not editable). The fork
+walks the tree for a node that is both **editable and focused** instead:
+when the event carries no source, walk `rootInActiveWindow` and pick the focused editable
+node.
+
+- **Works for:** native `EditText` fields that simply don't carry a source in their event.
+- **Does not work for:** WebView rich-text editors (e.g. ColorOS Notes). Their editable
+  HTML fields are *virtual* nodes never exposed through the accessibility child hierarchy
+  (`childCount` is 1 but `getChild(0)` returns null). This is a WebView accessibility
+  limitation, not a SwiftSlate bug.
+
+---
+
+## 5. Integration for upstream (recommended)
+
+We kept the patch isolated to `preview` so the stable build is untouched. For upstream we
+suggest the same pattern, possibly with a real feature flag:
+
+1. **Keep the two no-op services in a dedicated source set / optional build type** so
+   stable builds don't ship classes named after Google/Dianming (see "Ethical / Play
+   considerations").
+2. **Keep the `-keep` rules** with the exact class names — renaming silently breaks the
+   feature.
+3. **Keep the `srcNull` fallback** in `AssistantService` unconditionally: it is a pure
+   improvement for native EditText apps, independent of WeChat.
+4. **Make the Dashboard hint conditional** on the compat service actually being compiled in
+   (as done via `BuildConfig.WHITELIST_SERVICE`).
+5. **Re-verify the whitelist entries** on new WeChat releases. The two names are hard-coded
+   in WeChat's `AccExptServiceKt` clinit; if WeChat adds/removes entries, add/remove matching
+   no-op classes.
+
+### Testing checklist
+1. Install and enable SwiftSlate main service + one compat service.
+2. Open WeChat, enter a chat, focus the input.
+3. Confirm `adb logcat -s SwiftSlateDiag:E` shows `rootCls=android.widget.FrameLayout`
+   (not `null`) and `TEXT_CHANGED pkg=com.tencent.mm`.
+4. Type `hello world ?fix` and confirm the replacement lands in the input field.
+
+---
+
+## 6. Ethical / Play Store considerations (please read)
+
+- The no-op services borrow Google's and Dianming's class names purely to satisfy a string
+  comparison in WeChat's client. This is **local, self-use software** — no WeChat server
+  is touched, no data leaves the device differently than usual.
+- Shipping classes named `com.google.android.accessibility.selecttospeak.SelectToSpeakService`
+  in a **public** Play Store build is risky: Play Integrity, WeChat, or OEMs may treat a
+  service that impersonates a Google component as suspicious. **Keep it out of the stable
+  build** (that is exactly why it lives in `preview`).
+- If you want WeChat support in the stable channel without impersonation, the alternatives
+  are: (a) prompt users to enable TalkBack touch-exploration or Google's real
+  Select-to-Speak (both make `isAccessibilityEnabled()` return true), or (b) negotiate
+  with users to keep a preview build. Option (a) needs no code but has UX overhead.
+
+---
+
+## 7. Appendix: quick adb enable/disable
+
+```bash
+# Enable main service + Dianming compat (recommended pair)
+adb shell settings put secure enabled_accessibility_services \
+  "com.musheer360.swiftslate.preview/com.musheer360.swiftslate.service.AssistantService:\
+com.musheer360.swiftslate.preview/com.dianming.phoneapp.MyAccessibilityService"
+
+# Verify binding
+adb shell dumpsys accessibility | grep "Bound services"
+```
+
+(On the stable application id, substitute the package name accordingly.)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,11 @@ android {
         versionCode = (project.findProperty("versionCode") as String?)?.toIntOrNull() ?: 1
         versionName = (project.findProperty("versionName") as String?) ?: "$baseVersion-dev"
 
+        // Component name of the no-op accessibility service matching WeChat's
+        // anti-accessibility whitelist. Empty on stable builds (no such service exists there), so
+        // the WeChat compatibility hint in the Dashboard is preview-only; overridden below.
+        buildConfigField("String", "WHITELIST_SERVICE", "\"\"")
+
         // Ship exactly the locales that exist in res/, and nothing else.
         //
         // Derived from the directory listing on purpose. The previous hand-written
@@ -87,6 +92,12 @@ android {
             versionNameSuffix = "-preview"
             signingConfig = signingConfigs.getByName("debug")
             matchingFallbacks += listOf("release")
+            // Override with the no-op service whose class name matches WeChat's whitelist.
+            buildConfigField(
+                "String",
+                "WHITELIST_SERVICE",
+                "\"com.dianming.phoneapp.MyAccessibilityService\""
+            )
         }
     }
     compileOptions {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -3,6 +3,11 @@
 # Keep the accessibility service (instantiated by Android framework via reflection)
 -keep class com.musheer360.swiftslate.service.AssistantService { <init>(); }
 
+# Keep preview-only whitelist-compat services: their class names are the whole point
+# (WeChat matches them by exact fully-qualified name), so R8 must not rename them.
+-keep class com.google.android.accessibility.selecttospeak.SelectToSpeakService { <init>(); }
+-keep class com.dianming.phoneapp.MyAccessibilityService { <init>(); }
+
 # Keep enum values used in JSON serialization via CommandType.valueOf()
 -keepclassmembers enum com.musheer360.swiftslate.model.CommandType {
     public static **[] values();
@@ -13,11 +18,15 @@
 -keepattributes SourceFile,LineNumberTable
 -renamesourcefileattribute SourceFile
 
+# Keep Log.e: it carries the SwiftSlateDiag diagnostics used for field debugging.
+-keepclassmembers class android.util.Log {
+    public static int e(...);
+}
+
 # Remove debug logging in release
 -assumenosideeffects class android.util.Log {
     public static int v(...);
     public static int d(...);
     public static int i(...);
     public static int w(...);
-    public static int e(...);
 }

--- a/app/src/main/java/com/musheer360/swiftslate/service/AssistantService.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/service/AssistantService.kt
@@ -110,6 +110,9 @@ class AssistantService : AccessibilityService() {
 
     private companion object {
         const val TAG = "SwiftSlateService"
+        // Fork: field-debugging diagnostics (Log.e so R8 keeps them, see proguard-rules.pro).
+        // Filter with: adb logcat -s SwiftSlateDiag:E
+        const val DIAG_TAG = "SwiftSlateDiag"
         const val TRIGGER_REFRESH_INTERVAL_MS = 5_000L
         const val PROCESSING_WATCHDOG_MS = 120_000L
         const val FOCUS_FALLBACK_MIN_INTERVAL_MS = 300L
@@ -130,6 +133,56 @@ class AssistantService : AccessibilityService() {
             // event path and command path already handle an uninitialized manager (#125).
             Log.w(TAG, "onServiceConnected failed; service will stay inert until re-enabled", e)
         }
+        // A/B test: dump loop disabled — it forces rootInActiveWindow + full-tree walk every
+        // 3s, which keeps poking WeChat's accessibility delegate and makes the IME candidate
+        // bar jump. See WECHAT_COMPAT debug notes. Re-enable by uncommenting.
+        // startWindowDump()
+    }
+
+    private var dumpRunnable: Runnable? = null
+
+    private fun startWindowDump() {
+        dumpRunnable?.let { handler.removeCallbacks(it) }
+        val runnable = object : Runnable {
+            override fun run() {
+                dumpActiveWindow()
+                handler.postDelayed(this, 3000)
+            }
+        }
+        dumpRunnable = runnable
+        handler.postDelayed(runnable, 1500)
+    }
+
+    private fun dumpActiveWindow() {
+        try {
+            val root = rootInActiveWindow ?: run {
+                Log.e(DIAG_TAG, "dump: rootInActiveWindow null")
+                return
+            }
+            val pkg = root.packageName?.toString() ?: "?"
+            Log.e(DIAG_TAG, "== dump window pkg=$pkg winId=${root.windowId} rootCls=${root.className}")
+            if (pkg == "com.tencent.mm") {
+                dumpNode(root, 0)
+            }
+        } catch (e: Exception) {
+            Log.e(DIAG_TAG, "dump failed: ${e.message}")
+        }
+    }
+
+    private fun dumpNode(node: AccessibilityNodeInfo, depth: Int) {
+        try {
+            val cls = node.className?.toString() ?: "?"
+            val isEdit = cls.contains("EditText") || node.isEditable
+            if (isEdit || node.isFocused || depth < 2) {
+                Log.e(DIAG_TAG, "node[$depth] cls=$cls editable=${node.isEditable} imp=${node.isImportantForAccessibility} foc=${node.isFocused} text=${node.text} id=${node.viewIdResourceName}")
+            }
+            for (i in 0 until node.childCount) {
+                try {
+                    val child = node.getChild(i) ?: continue
+                    dumpNode(child, depth + 1)
+                } catch (_: Exception) {}
+            }
+        } catch (_: Exception) {}
     }
 
     private fun updateTriggers() {
@@ -191,28 +244,35 @@ class AssistantService : AccessibilityService() {
 
     private fun handleAccessibilityEvent(event: AccessibilityEvent?) {
         if (event?.eventType != AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED) return
+        Log.e(DIAG_TAG, "TEXT_CHANGED pkg=${event.packageName} srcNull=${event.source == null}")
         if (event.packageName?.toString() == packageName) return
         if (!::keyManager.isInitialized) return
 
         // Some hosts (WeChat-style editors, WebView fields) emit text-changed events whose
-        // source node is null or already recycled. Fall back to the focused input node of the
-        // active window before giving up — see #125 / #131. The root lookup is a binder call on
-        // the main thread, so it is throttled: hosts that flood null-source events are rare, and
-        // skipping an occasional event is harmless for trigger detection.
+        // source node is null or already recycled. Fall back to the focused editable input node
+        // of the active window before giving up — see #125 / #131. The root lookup is a binder
+        // call on the main thread, so it is throttled: hosts that flood null-source events are
+        // rare, and skipping an occasional event is harmless for trigger detection.
         val source = event.source ?: run {
             val now = SystemClock.elapsedRealtime()
             if (now - lastFocusFallbackAt < FOCUS_FALLBACK_MIN_INTERVAL_MS) return
             lastFocusFallbackAt = now
             findFocusedEditableSource()
-        } ?: return
+        } ?: run {
+            Log.e(DIAG_TAG, "source null, abort")
+            return
+        }
         if (source.isPassword) {
+            Log.e(DIAG_TAG, "password field, skip")
             source.safeRecycle()
             return
         }
         val text = source.text?.toString() ?: run {
+            Log.e(DIAG_TAG, "text is NULL (wechat fake/clear info?), class=${source.className}")
             source.safeRecycle()
             return
         }
+        Log.e(DIAG_TAG, "text=[$text] class=${source.className} editable=${source.isEditable}")
         if (handlePendingProcessTextReplacement(event, source, text)) return
         if (isProcessing.get()) {
             source.safeRecycle()
@@ -244,13 +304,16 @@ class AssistantService : AccessibilityService() {
 
         val lastChar = text[text.length - 1]
         if (!triggerLastChars.contains(lastChar)) {
+            Log.e(DIAG_TAG, "lastChar=[$lastChar] not in triggers=$triggerLastChars")
             if (!lastChar.isLetterOrDigit() || !text.contains(cachedTranslatePrefix)) {
                 source.safeRecycle()
                 return
             }
         }
 
-        val command = commandManager.findCommand(text) ?: run {
+        val command = commandManager.findCommand(text)
+        Log.e(DIAG_TAG, "findCommand result=${command?.trigger}")
+        if (command == null) {
             source.safeRecycle()
             return
         }
@@ -348,6 +411,11 @@ class AssistantService : AccessibilityService() {
      * node of the active window. Returns null when unavailable; the caller treats the result
      * exactly like a null event.source and recycles it like one. All node access is guarded —
      * the root can be stale the moment we ask (#125).
+     *
+     * Fork: instead of findFocus(FOCUS_INPUT) (which returns the WebView/container node for
+     * WebView-based editors — not editable), walk the tree for the node that is both editable
+     * and focused. The walk recycles every node it visits, so callers must treat the result
+     * exactly like an event source.
      */
     private fun findFocusedEditableSource(): AccessibilityNodeInfo? {
         val root = try {
@@ -356,16 +424,32 @@ class AssistantService : AccessibilityService() {
             Log.w(TAG, "focused-node fallback: root unavailable", e)
             null
         } ?: return null
-        try {
-            val focused = root.findFocus(AccessibilityNodeInfo.FOCUS_INPUT)
-            if (focused === root) return root
-            root.safeRecycle()
-            return focused
+        return try {
+            findFocusedEditable(root)
         } catch (e: Exception) {
             Log.w(TAG, "focused-node fallback failed", e)
             root.safeRecycle()
+            null
+        }
+    }
+
+    private fun findFocusedEditable(node: AccessibilityNodeInfo): AccessibilityNodeInfo? {
+        val edit = runCatching { node.isEditable }.getOrElse { false }
+        if (edit && runCatching { node.isFocused }.getOrElse { false }) return node
+        if (node.childCount == 0) {
+            node.safeRecycle()
             return null
         }
+        for (i in 0 until node.childCount) {
+            val child = node.getChild(i) ?: continue
+            val found = findFocusedEditable(child)
+            if (found != null) {
+                node.safeRecycle()
+                return found
+            }
+        }
+        node.safeRecycle()
+        return null
     }
 
     private fun handlePendingProcessTextReplacement(
@@ -781,11 +865,15 @@ class AssistantService : AccessibilityService() {
         // must not restore or clear it — that destroyed the very clip the command just placed.
         callerOwnsClipboard: Boolean = false
     ): Boolean = withContext(Dispatchers.Main) {
-        if (!source.refresh()) return@withContext false
+        if (!source.refresh()) {
+            Log.e(DIAG_TAG, "replaceText: refresh failed")
+            return@withContext false
+        }
         val bundle = Bundle()
         bundle.putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, newText)
 
         val success = source.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, bundle)
+        Log.e(DIAG_TAG, "replaceText: ACTION_SET_TEXT=$success text=[$newText]")
 
         if (success) {
             // Verify the text actually persisted — some apps (Firefox, Google Keep)
@@ -798,6 +886,7 @@ class AssistantService : AccessibilityService() {
                 return@withContext false
             }
             val currentText = source.text?.toString()
+            Log.e(DIAG_TAG, "replaceText: verify after SET_TEXT=[$currentText]")
             if (currentText == newText) {
                 scheduleTextVerification(source, newText)
                 return@withContext true // Text persisted
@@ -838,6 +927,7 @@ class AssistantService : AccessibilityService() {
         source.performAction(AccessibilityNodeInfo.ACTION_SET_SELECTION, selectAllArgs)
 
         val pasted = source.performAction(AccessibilityNodeInfo.ACTION_PASTE)
+        Log.e(DIAG_TAG, "replaceText: clipboard fallback PASTE=$pasted")
 
         scheduleTextVerification(source, newText)
 

--- a/app/src/main/java/com/musheer360/swiftslate/ui/DashboardScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/DashboardScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
+import com.musheer360.swiftslate.BuildConfig
 import com.musheer360.swiftslate.R
 import com.musheer360.swiftslate.SwiftSlateApp
 import com.musheer360.swiftslate.manager.CommandManager
@@ -45,6 +46,23 @@ private fun checkServiceEnabled(context: Context): Boolean {
     val enabledServices = am.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_GENERIC)
     return enabledServices.any {
         it.resolveInfo.serviceInfo.packageName == context.packageName
+    }
+}
+
+/**
+ * True when the no-op whitelist service (the one whose class name matches WeChat's
+ * accessibility whitelist) is enabled. [checkServiceEnabled] covers the main SwiftSlate
+ * service; this one is about the companion service that keeps WeChat from wiping the
+ * node tree. Empty on stable builds (no such service exists there), so it reports enabled.
+ */
+private fun checkWhitelistServiceEnabled(context: Context): Boolean {
+    val component = BuildConfig.WHITELIST_SERVICE
+    if (component.isEmpty()) return true
+    val am = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+    val enabledServices = am.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_GENERIC)
+    return enabledServices.any {
+        it.resolveInfo.serviceInfo.name == component ||
+            it.resolveInfo.serviceInfo.name.substringAfterLast('.') == component.substringAfterLast('.')
     }
 }
 
@@ -94,6 +112,7 @@ fun DashboardScreen(keyManager: KeyManager, commandManager: CommandManager, stat
     val context = LocalContext.current
     val haptic = LocalHapticFeedback.current
     var isServiceEnabled by remember { mutableStateOf(checkServiceEnabled(context)) }
+    var isWhitelistEnabled by remember { mutableStateOf(checkWhitelistServiceEnabled(context)) }
     // Not seeded from keyManager.getKeys(): that decrypts through AndroidKeyStore on the main
     // thread. The LaunchedEffect below fills it in on the IO dispatcher, as it already did on
     // every subsequent resume.
@@ -113,6 +132,7 @@ fun DashboardScreen(keyManager: KeyManager, commandManager: CommandManager, stat
         val am = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
         val listener = AccessibilityManager.AccessibilityStateChangeListener {
             isServiceEnabled = checkServiceEnabled(context)
+            isWhitelistEnabled = checkWhitelistServiceEnabled(context)
         }
         am.addAccessibilityStateChangeListener(listener)
         onDispose { am.removeAccessibilityStateChangeListener(listener) }
@@ -128,7 +148,10 @@ fun DashboardScreen(keyManager: KeyManager, commandManager: CommandManager, stat
                     readCrashMarker(context) > 0L || isServiceCrashed(context)
                 )
             }
+            // In-memory read of the accessibility service list — no keychain decrypt involved.
+            val newWhitelist = checkWhitelistServiceEnabled(context)
             isServiceEnabled = newEnabled
+            isWhitelistEnabled = newWhitelist
             keyCount = newKeyCount
             monthlyRequests = statsManager.monthlyRequests
             favoriteCommand = statsManager.favoriteCommand
@@ -190,6 +213,44 @@ fun DashboardScreen(keyManager: KeyManager, commandManager: CommandManager, stat
             Spacer(modifier = Modifier.height(12.dp))
             SlateDivider()
             Spacer(modifier = Modifier.height(12.dp))
+
+            // Preview builds ship a no-op accessibility service whose class name matches
+            // WeChat's anti-accessibility whitelist. When the main service is on but that
+            // companion is off, WeChat keeps wiping the node tree — surface it here so the
+            // user knows both must be enabled.
+            if (isServiceEnabled && !isWhitelistEnabled) {
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(10.dp),
+                    color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f)
+                ) {
+                    Column(modifier = Modifier.padding(12.dp)) {
+                        Text(
+                            text = stringResource(R.string.dashboard_wechat_hint_title),
+                            fontSize = 13.sp,
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = stringResource(R.string.dashboard_wechat_hint_body),
+                            fontSize = 12.sp,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Button(
+                            onClick = {
+                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                context.startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
+                            },
+                            shape = RoundedCornerShape(8.dp)
+                        ) {
+                            Text(stringResource(R.string.dashboard_wechat_hint_action))
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+            }
 
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
@@ -1,6 +1,8 @@
 package com.musheer360.swiftslate.ui
 
+import android.content.Intent
 import android.content.SharedPreferences
+import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
@@ -596,6 +598,34 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 ) {
                     Text(stringResource(R.string.backup_import))
                 }
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        context.startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
+                    },
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(R.string.settings_accessibility_title),
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = stringResource(R.string.settings_accessibility_open),
+                    fontSize = 13.sp,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = "›",
+                    fontSize = 18.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
             backupMessage?.let { msg ->
                 Text(

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -144,4 +144,13 @@
     <string name="dashboard_service_killed_title">SwiftSlate 已中断</string>
     <string name="dashboard_service_killed_message">后台服务意外停止。请在无障碍设置中重新启用它，以继续使用命令。</string>
     <string name="dashboard_service_killed_dismiss">忽略</string>
+
+    <!-- 微信兼容（仅 preview 提示） -->
+    <string name="dashboard_wechat_hint_title">微信兼容</string>
+    <string name="dashboard_wechat_hint_body">微信会拦截文本替换，除非同时启用配套的兼容服务。请在 SwiftSlate 助手旁一并启用它。</string>
+    <string name="dashboard_wechat_hint_action">打开无障碍设置</string>
+
+    <!-- 设置：无障碍 -->
+    <string name="settings_accessibility_title">无障碍</string>
+    <string name="settings_accessibility_open">打开设置</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -145,4 +145,13 @@
     <string name="dashboard_service_killed_title">SwiftSlate 已中断</string>
     <string name="dashboard_service_killed_message">后台服务意外停止。请在无障碍设置中重新启用它，以继续使用命令。</string>
     <string name="dashboard_service_killed_dismiss">忽略</string>
+
+    <!-- 微信兼容（仅 preview 提示） -->
+    <string name="dashboard_wechat_hint_title">微信兼容</string>
+    <string name="dashboard_wechat_hint_body">微信会拦截文本替换，除非同时启用配套的兼容服务。请在 SwiftSlate 助手旁一并启用它。</string>
+    <string name="dashboard_wechat_hint_action">打开无障碍设置</string>
+
+    <!-- 设置：无障碍 -->
+    <string name="settings_accessibility_title">无障碍</string>
+    <string name="settings_accessibility_open">打开设置</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,4 +151,13 @@
     <string name="dashboard_service_killed_title">SwiftSlate was interrupted</string>
     <string name="dashboard_service_killed_message">The background service stopped unexpectedly. Re-enable it in accessibility settings to keep using commands.</string>
     <string name="dashboard_service_killed_dismiss">Dismiss</string>
+
+    <!-- WeChat compatibility (preview-only hint) -->
+    <string name="dashboard_wechat_hint_title">WeChat compatibility</string>
+    <string name="dashboard_wechat_hint_body">WeChat blocks text replacement unless the companion compatibility service is also on. Enable it alongside SwiftSlate Assistant.</string>
+    <string name="dashboard_wechat_hint_action">Open Accessibility Settings</string>
+
+    <!-- Settings: accessibility -->
+    <string name="settings_accessibility_title">Accessibility</string>
+    <string name="settings_accessibility_open">Open Settings</string>
 </resources>

--- a/app/src/preview/AndroidManifest.xml
+++ b/app/src/preview/AndroidManifest.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Preview-only compatibility services that make WeChat stop clearing its
+  accessibility node tree. Their class names match WeChat's whitelist
+  (`DefaultWhiteServiceList`), so `checkHasServiceInList()` containment check
+  hits without needing Google's Select to Speak or Dianming installed/enabled.
+  They are no-ops. Deliberately absent from the stable build.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <service
+            android:name="com.google.android.accessibility.selecttospeak.SelectToSpeakService"
+            android:exported="true"
+            android:label="@string/fake_whitelist_google_label"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/fake_accessibility_service_config" />
+        </service>
+
+        <service
+            android:name="com.dianming.phoneapp.MyAccessibilityService"
+            android:exported="true"
+            android:label="@string/fake_whitelist_dianming_label"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/fake_accessibility_service_config" />
+        </service>
+    </application>
+
+</manifest>

--- a/app/src/preview/java/com/dianming/phoneapp/MyAccessibilityService.kt
+++ b/app/src/preview/java/com/dianming/phoneapp/MyAccessibilityService.kt
@@ -1,0 +1,17 @@
+package com.dianming.phoneapp
+
+import android.accessibilityservice.AccessibilityService
+import android.view.accessibility.AccessibilityEvent
+
+/**
+ * SwiftSlate preview-only compatibility service.
+ *
+ * Its fully-qualified class name deliberately matches the second entry in WeChat's
+ * accessibility-service whitelist (`DefaultWhiteServiceList`), so WeChat's
+ * `checkHasServiceInList()` string-containment check hits. Redundant with
+ * [SelectToSpeakService] but cheap insurance if WeChat rotates one whitelist entry.
+ */
+class MyAccessibilityService : AccessibilityService() {
+    override fun onAccessibilityEvent(event: AccessibilityEvent?) = Unit
+    override fun onInterrupt() = Unit
+}

--- a/app/src/preview/java/com/google/android/accessibility/selecttospeak/SelectToSpeakService.kt
+++ b/app/src/preview/java/com/google/android/accessibility/selecttospeak/SelectToSpeakService.kt
@@ -1,0 +1,19 @@
+package com.google.android.accessibility.selecttospeak
+
+import android.accessibilityservice.AccessibilityService
+import android.view.accessibility.AccessibilityEvent
+
+/**
+ * SwiftSlate preview-only compatibility service.
+ *
+ * Its fully-qualified class name deliberately matches the entry in WeChat's
+ * accessibility-service whitelist (`DefaultWhiteServiceList`), so WeChat's
+ * `checkHasServiceInList()` string-containment check
+ * (`pkg/name`.contains("com.google.android.accessibility.selecttospeak.SelectToSpeakService"))
+ * hits and `AccUtil.isAccessibilityEnabled()` returns true, which stops WeChat from
+ * clearing/faking its accessibility node tree. It performs no real work.
+ */
+class SelectToSpeakService : AccessibilityService() {
+    override fun onAccessibilityEvent(event: AccessibilityEvent?) = Unit
+    override fun onInterrupt() = Unit
+}

--- a/app/src/preview/res/values/strings.xml
+++ b/app/src/preview/res/values/strings.xml
@@ -8,4 +8,6 @@
 <resources>
     <string name="app_name">SwiftSlate Preview</string>
     <string name="accessibility_service_label">SwiftSlate Preview</string>
+    <string name="fake_whitelist_google_label">SwiftSlate 微信适配（备选）</string>
+    <string name="fake_whitelist_dianming_label">SwiftSlate 微信适配</string>
 </resources>

--- a/app/src/preview/res/xml/fake_accessibility_service_config.xml
+++ b/app/src/preview/res/xml/fake_accessibility_service_config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Preview-only minimal config for the whitelist-name compatibility services.
+
+  A/B experiment for the WeChat candidate-bar jumping issue:
+  the shared main config declares `canRetrieveWindowContent="true"` and subscribes
+  to `typeViewTextChanged`, which WeChat/its IME reacts to by repeatedly refreshing
+  the candidate bar even though the compatibility services perform no work.
+
+  These services exist only to make WeChat's `checkHasServiceInList()` string
+  containment check pass (the whitelist is matched purely on the fully-qualified
+  class name), so they need neither window content retrieval nor event delivery.
+  If removing both capabilities stops the candidate-bar jumping, the root cause is
+  confirmed to be "enabling a window-reading accessibility service", not SwiftSlate
+  code, and this config becomes the permanent fix.
+-->
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeNotificationStateChanged"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:description="@string/accessibility_service_desc" />

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,7 @@ android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
 
+# Fork: SwiftSlate 微信适配版 (v1.0.76). Overridden by -PversionName/-PversionCode in CI.
+versionName=1.0.76
+versionCode=227
+


### PR DESCRIPTION
Re-apply the WeChat anti-accessibility bypass on top of upstream v1.0.76 (cabd098). Upstream adopted the srcNull fallback in #125, so this branch adds only: the preview-only whitelist-name no-op services (SelectToSpeakService / MyAccessibilityService), the recursive editable+focused node search refinement, SwiftSlateDiag Log.e diagnostics, and the Dashboard / Settings hints. WHITELIST_SERVICE now lives in defaultConfig (empty) so stable builds compile, unlike the v1.0.73 patch which only defined it in preview.

Verified on device (Realme RMX2202, Android 14): with the dianming fake service plus the main service enabled, WeChat stops wiping the node tree (srcNull=false, text readable) and `hello world ，fix` replaces to `Hello world.` end-to-end.

Generated with Codebuff 🤖

## What does this PR do?

<!-- Brief description of the change -->

## Type of change

- [ ] Bug fix (Accessibility Service, API handling, UI)
- [ ] New command (built-in AI or text replacer)
- [ ] New provider integration
- [ ] UI / theme change
- [ ] Translation / localization
- [ ] Refactor (no behavior change)
- [ ] Documentation

## Testing

- [ ] Tested with Accessibility Service enabled on a real device
- [ ] Verified trigger detection still works in WhatsApp / Gmail / Notes
- [ ] Text replacer commands execute instantly (no regressions)
- [ ] AI commands return proper responses with Gemini / Groq
- [ ] Password fields are still ignored
- [ ] If touching `service/CommandRunner.kt` or `ui/processtext/`, tested the text-selection
  popup too (with accessibility enabled and disabled)
- [ ] No new external dependencies added

## Checklist

- [ ] Builds cleanly with `./gradlew assembleDebug`
- [ ] No hardcoded API keys or secrets
- [ ] Follows existing code style (no new linters/formatters)
- [ ] Works on API 23+ (no higher-API-only calls without version checks)
