### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,11 +750,11 @@ This project is licensed under the **MIT License** — see the [LICENSE](LICENSE
 
 <div align="center">
 
-<a href="https://star-history.com/#Musheer360/SwiftSlate&Date">
+<a href="https://star-history.dera.page/#Musheer360/SwiftSlate&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Musheer360/SwiftSlate&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Musheer360/SwiftSlate&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Musheer360/SwiftSlate&type=Date" width="600" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Musheer360/SwiftSlate&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Musheer360/SwiftSlate&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Musheer360/SwiftSlate&type=Date" width="600" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README no longer renders because the current service is broken under GitHub's stargazer API restrictions. This change points it to a working alternative so the chart shows up again.