### PR TITLE
Add a bounded recursive fallback to find the focused editable node

### DIFF
--- a/app/src/main/java/com/musheer360/swiftslate/service/AssistantService.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/service/AssistantService.kt
@@ -348,6 +348,11 @@ class AssistantService : AccessibilityService() {
      * node of the active window. Returns null when unavailable; the caller treats the result
      * exactly like a null event.source and recycles it like one. All node access is guarded —
      * the root can be stale the moment we ask (#125).
+     *
+     * Two-stage: `findFocus(FOCUS_INPUT)` keeps precedence (it surfaces sources upstream
+     * accepts), and a bounded recursive search for an editable+focused node runs only when
+     * `findFocus` reports nothing — some hosts expose the input deeper in the tree than
+     * `findFocus` reaches.
      */
     private fun findFocusedEditableSource(): AccessibilityNodeInfo? {
         val root = try {
@@ -359,8 +364,14 @@ class AssistantService : AccessibilityService() {
         try {
             val focused = root.findFocus(AccessibilityNodeInfo.FOCUS_INPUT)
             if (focused === root) return root
-            root.safeRecycle()
-            return focused
+            if (focused != null) {
+                root.safeRecycle()
+                return focused
+            }
+            // Second stage: findFocus found nothing, so walk the tree for an editable+focused
+            // node. The walk recycles every visited node except the match it returns.
+            val found = FocusedEditableFinder.find(AccessibilityFocusNode(root)) as? AccessibilityFocusNode
+            return found?.node
         } catch (e: Exception) {
             Log.w(TAG, "focused-node fallback failed", e)
             root.safeRecycle()

--- a/app/src/main/java/com/musheer360/swiftslate/service/FocusedEditableFinder.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/service/FocusedEditableFinder.kt
@@ -1,0 +1,88 @@
+package com.musheer360.swiftslate.service
+
+import android.view.accessibility.AccessibilityNodeInfo
+
+/**
+ * Minimal seam over a node in the accessibility tree so the fallback walk can be unit-tested
+ * with a fake tree. The real accessibility API can throw [IllegalStateException] from any
+ * accessor when the underlying view has gone away, so implementations are free to throw and
+ * [FocusedEditableFinder] must tolerate it.
+ */
+internal interface FocusNode {
+    val isEditable: Boolean
+    val isFocused: Boolean
+    val childCount: Int
+
+    /** May return null for a recycled/gone child; may throw like the real API. */
+    fun getChild(index: Int): FocusNode?
+
+    fun recycle()
+}
+
+/**
+ * Bounded depth-first search for the node that is both editable and focused.
+ *
+ * This is the second-stage fallback behind [AccessibilityNodeInfo.findFocus]`(FOCUS_INPUT)`:
+ * `findFocus` keeps precedence (it can return container nodes upstream still accepts), and this
+ * walk only runs when `findFocus` reports nothing. Some hosts expose the editable input only as
+ * a deeper node that `findFocus` does not surface.
+ *
+ * The walk is deliberately bounded so a pathological or very deep tree cannot spike the main
+ * thread: at most [NODE_BUDGET] nodes are visited and the recursion never goes deeper than
+ * [MAX_DEPTH]. Every visited node is recycled on the way out — including when a node method
+ * throws mid-walk — except the node returned as the match, which the caller takes ownership of.
+ */
+internal object FocusedEditableFinder {
+
+    const val NODE_BUDGET = 500
+    const val MAX_DEPTH = 32
+
+    fun find(root: FocusNode): FocusNode? {
+        var remaining = NODE_BUDGET
+
+        fun walk(node: FocusNode, depth: Int): FocusNode? {
+            // Recycle `node` on every exit except when it is the returned match. The finally
+            // block guarantees recycling even when an accessor throws mid-walk.
+            var keep = false
+            try {
+                if (remaining <= 0 || depth > MAX_DEPTH) return null
+                remaining--
+                if (node.isEditable && node.isFocused) {
+                    keep = true
+                    return node
+                }
+                val childCount = node.childCount
+                for (i in 0 until childCount) {
+                    val child = node.getChild(i) ?: continue
+                    val found = walk(child, depth + 1)
+                    if (found != null) return found
+                }
+                return null
+            } catch (e: Exception) {
+                // The node went stale mid-walk. Treat this branch as a miss; `finally` recycles
+                // this frame's node and children already visited were recycled in their frames.
+                return null
+            } finally {
+                if (!keep) node.recycle()
+            }
+        }
+
+        return walk(root, 0)
+    }
+}
+
+/** Bridges a real [AccessibilityNodeInfo] to [FocusNode] without swallowing its exceptions. */
+internal class AccessibilityFocusNode(val node: AccessibilityNodeInfo) : FocusNode {
+    override val isEditable: Boolean get() = node.isEditable
+    override val isFocused: Boolean get() = node.isFocused
+    override val childCount: Int get() = node.childCount
+    override fun getChild(index: Int): FocusNode? =
+        node.getChild(index)?.let(::AccessibilityFocusNode)
+
+    override fun recycle() {
+        try {
+            node.recycle()
+        } catch (_: Exception) {
+        }
+    }
+}

--- a/app/src/test/java/com/musheer360/swiftslate/service/FocusedEditableFinderTest.kt
+++ b/app/src/test/java/com/musheer360/swiftslate/service/FocusedEditableFinderTest.kt
@@ -1,0 +1,116 @@
+package com.musheer360.swiftslate.service
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Exercises [FocusedEditableFinder] against a fake tree, since the real
+ * [android.view.accessibility.AccessibilityNodeInfo] is Binder-backed and unavailable under the
+ * JVM. The fake mirrors the one thing that matters here: accessors can throw once a node is
+ * stale, and `recycle()` records whether the walk cleaned up after itself.
+ */
+private class FakeNode(
+    val name: String,
+    override val isEditable: Boolean = false,
+    override val isFocused: Boolean = false,
+    val children: MutableList<FakeNode> = mutableListOf(),
+    val throwOnChildAccess: Boolean = false,
+) : FocusNode {
+    var recycled = false
+        private set
+
+    override val childCount: Int
+        get() {
+            if (throwOnChildAccess) throw IllegalStateException("stale node: $name")
+            return children.size
+        }
+
+    override fun getChild(index: Int): FocusNode? {
+        if (throwOnChildAccess) throw IllegalStateException("stale node: $name")
+        return children.getOrNull(index)
+    }
+
+    override fun recycle() {
+        recycled = true
+    }
+}
+
+class FocusedEditableFinderTest {
+
+    @Test
+    fun matchAtRoot_returnsTheRootWithoutRecycling() {
+        val root = FakeNode("root", isEditable = true, isFocused = true)
+        assertSame(root, FocusedEditableFinder.find(root))
+        assertFalse(root.recycled)
+    }
+
+    @Test
+    fun deepMatch_returnsTheLeafAndRecyclesItsAncestors() {
+        val leaf = FakeNode("leaf", isEditable = true, isFocused = true)
+        val mid = FakeNode("mid", children = mutableListOf(leaf))
+        val root = FakeNode("root", children = mutableListOf(mid))
+
+        assertSame(leaf, FocusedEditableFinder.find(root))
+        assertTrue(root.recycled)
+        assertTrue(mid.recycled)
+        assertFalse(leaf.recycled)
+    }
+
+    @Test
+    fun miss_recyclesEveryVisitedNode() {
+        val grandchild = FakeNode("grandchild")
+        val left = FakeNode("left", children = mutableListOf(grandchild))
+        val right = FakeNode("right")
+        val root = FakeNode("root", children = mutableListOf(left, right))
+
+        assertNull(FocusedEditableFinder.find(root))
+        assertTrue(root.recycled)
+        assertTrue(left.recycled)
+        assertTrue(right.recycled)
+        assertTrue(grandchild.recycled)
+    }
+
+    @Test
+    fun budgetCap_stopsBeforeAChainLongerThanTheBudget() {
+        // One node past the budget, with the only match at the far end of a linear chain.
+        val chain = (0..FocusedEditableFinder.NODE_BUDGET).map { i ->
+            val last = i == FocusedEditableFinder.NODE_BUDGET
+            FakeNode("n$i", isEditable = last, isFocused = last)
+        }
+        for (i in 0 until chain.size - 1) chain[i].children.add(chain[i + 1])
+
+        assertNull(FocusedEditableFinder.find(chain.first()))
+    }
+
+    @Test
+    fun depthCap_stopsBeforeAMatchBeyondMaxDepth() {
+        val chain = (0..FocusedEditableFinder.MAX_DEPTH + 1).map { i ->
+            val last = i == FocusedEditableFinder.MAX_DEPTH + 1
+            FakeNode("n$i", isEditable = last, isFocused = last)
+        }
+        for (i in 0 until chain.size - 1) chain[i].children.add(chain[i + 1])
+
+        assertNull(FocusedEditableFinder.find(chain.first()))
+    }
+
+    @Test
+    fun exceptionMidWalk_recyclesEveryNodeAlreadyVisited() {
+        val healthy = FakeNode("healthy")
+        val stale = FakeNode(
+            "stale",
+            throwOnChildAccess = true,
+            children = mutableListOf(FakeNode("unreachable-child")),
+        )
+        val root = FakeNode("root", children = mutableListOf(healthy, stale))
+
+        // stale.childCount throws mid-walk; the walk must not crash and must not leak the
+        // nodes it already obtained.
+        assertNull(FocusedEditableFinder.find(root))
+        assertTrue(root.recycled)
+        assertTrue(healthy.recycled)
+        assertTrue(stale.recycled)
+    }
+}


### PR DESCRIPTION
Re-submission of the focused-editable node search from #139, scoped down to just the refinement the maintainer requested.

## What changed

`findFocusedEditableSource()` now runs in two stages:

1. `findFocus(FOCUS_INPUT)` first — unchanged, keeps precedence (its non-null result is returned as-is).
2. Only when `findFocus` reports nothing, a bounded depth-first search walks the tree for the node that is both `isEditable` and `isFocused`.

This helps hosts that expose the editable input deeper in the tree than `findFocus` reaches, without disturbing any source the stage-1 already accepts.

## Guardrails (from the #139 review)

- **Second stage only** — upstream's `findFocus` result keeps precedence.
- **Budget + depth cap** — 500 nodes / depth 32, behind the existing 300 ms throttle in `handleAccessibilityEvent`.
- **Full recycling on every path** — every visited node is recycled on exit (via `finally`), including when an accessor throws mid-walk; only the returned match is kept for the caller.
- **No `Log.e` diagnostics, no proguard changes** — this PR touches only `AssistantService.kt` plus two new files.

## Structure

- `FocusedEditableFinder.kt` — a `FocusNode` seam plus the bounded, recycling walk, so the logic is unit-testable with a fake tree.
- `AssistantService.kt` — wires the two-stage fallback through `AccessibilityFocusNode`.
- `FocusedEditableFinderTest.kt` — 6 tests: match-at-root, deep match, miss recycles everything, budget cap, depth cap, exception path.

`./gradlew testDebugUnitTest` and `./gradlew lintDebug` pass locally.