### PR TITLE
feat(settings): real-time dynamic Gemini/Groq model lists + bundle dependabot updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 21
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -175,7 +175,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 21
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -227,7 +227,7 @@ jobs:
           ref: ${{ needs.version.outputs.tag }}
 
       - name: Set up JDK 21
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -475,7 +475,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 21
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Resolve PR number and artifact
         id: resolve
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             // Resolve workflow run (either the triggering run or a manual run_id)
@@ -207,7 +207,7 @@ jobs:
 
       - name: Create or update comment (idempotent)
         if: steps.resolve.outputs.pr != ''
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const pr = parseInt('${{ steps.resolve.outputs.pr }}', 10);

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -130,7 +130,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.11.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.11.0")
     implementation("androidx.activity:activity-compose:1.13.0")
-    implementation(platform("androidx.compose:compose-bom:2026.06.01"))
+    implementation(platform("androidx.compose:compose-bom:2026.08.00"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.material3:material3")

--- a/app/src/main/java/com/musheer360/swiftslate/api/GeminiClient.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/api/GeminiClient.kt
@@ -8,6 +8,7 @@ import java.net.ConnectException
 import java.net.HttpURLConnection
 import java.net.SocketTimeoutException
 import java.net.URL
+import java.net.URLEncoder
 import java.net.UnknownHostException
 
 class GeminiClient {
@@ -111,7 +112,10 @@ class GeminiClient {
         try {
             var pages = 0
             while (true) {
-                val pageSuffix = if (pageToken.isNullOrEmpty()) "" else "&pageToken=$pageToken"
+                // Opaque tokens may contain '+', '/' or '=' — raw interpolation corrupts
+                // the query string ('+' decodes to a space server-side), so encode it.
+                val pageSuffix = if (pageToken.isNullOrEmpty()) ""
+                    else "&pageToken=" + URLEncoder.encode(pageToken, "UTF-8")
                 var connection: HttpURLConnection? = null
                 val responseCode: Int
                 val body: String

--- a/app/src/main/java/com/musheer360/swiftslate/api/GeminiClient.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/api/GeminiClient.kt
@@ -14,6 +14,49 @@ class GeminiClient {
 
     companion object {
         private val HTTP_PREFIX_REGEX = Regex("^HTTP_\\d+:\\s*")
+        private const val MODELS_URL = "https://generativelanguage.googleapis.com/v1beta/models"
+        // The listing paginates; pageSize caps at 1000. Three pages is far beyond any
+        // realistic catalog — a bound so a hostile/broken nextPageToken loop cannot spin.
+        private const val MAX_LIST_PAGES = 3
+
+        /**
+         * Extracts chat-capable model ids from a v1beta/models response page. An entry
+         * is kept when either documented capability array names "generateContent";
+         * entries carrying neither array are kept (fail-open: a renamed field must not
+         * empty the whole dropdown). The leading "models/" path prefix is stripped;
+         * ids are de-duplicated in first-seen order; non-JSON bodies yield an empty list.
+         *
+         * Exposed for unit tests — the network path around it is not JVM-testable.
+         */
+        internal fun parseModelsJson(json: String): List<String> {
+            if (json.isBlank()) return emptyList()
+            return try {
+                val arr = JSONObject(json).optJSONArray("models") ?: return emptyList()
+                val out = LinkedHashSet<String>()
+                for (i in 0 until arr.length()) {
+                    val obj = arr.optJSONObject(i) ?: continue
+                    val methods = obj.optJSONArray("supportedGenerationMethods")
+                    val actions = obj.optJSONArray("supportedActions")
+                    if (methods != null || actions != null) {
+                        val supportsChat = arrayContains(methods, "generateContent") ||
+                            arrayContains(actions, "generateContent")
+                        if (!supportsChat) continue
+                    }
+                    obj.optString("name").trim()
+                        .takeIf { it.isNotBlank() }
+                        ?.let { out.add(it.removePrefix("models/")) }
+                }
+                out.toList()
+            } catch (_: Exception) {
+                emptyList()
+            }
+        }
+
+        private fun arrayContains(arr: JSONArray?, value: String): Boolean {
+            if (arr == null) return false
+            for (i in 0 until arr.length()) if (arr.optString(i) == value) return true
+            return false
+        }
     }
 
     suspend fun validateKey(apiKey: String): Result<String> = withContext(Dispatchers.IO) {
@@ -53,6 +96,66 @@ class GeminiClient {
             Result.failure(e)
         } finally {
             connection?.disconnect()
+        }
+    }
+
+    /**
+     * Lists the chat-capable models available to [apiKey] via GET v1beta/models,
+     * powering the Settings screen's dynamic model dropdown (issue #148). Follows
+     * nextPageToken for up to [MAX_LIST_PAGES] pages; non-chat entries are dropped
+     * by [parseModelsJson]. Error mapping mirrors [validateKey].
+     */
+    suspend fun fetchModels(apiKey: String): Result<List<String>> = withContext(Dispatchers.IO) {
+        val collected = LinkedHashSet<String>()
+        var pageToken: String? = null
+        try {
+            var pages = 0
+            while (true) {
+                val pageSuffix = if (pageToken.isNullOrEmpty()) "" else "&pageToken=$pageToken"
+                var connection: HttpURLConnection? = null
+                val responseCode: Int
+                val body: String
+                try {
+                    connection = URL("$MODELS_URL?pageSize=1000$pageSuffix")
+                        .openConnection() as HttpURLConnection
+                    connection.requestMethod = "GET"
+                    connection.setRequestProperty("x-goog-api-key", apiKey)
+                    connection.connectTimeout = 15_000
+                    connection.readTimeout = 15_000
+
+                    responseCode = connection.responseCode
+                    body = if (responseCode in 200..299) {
+                        ApiClientUtils.readResponseBounded(connection)
+                    } else {
+                        ApiClientUtils.readErrorBody(connection)
+                    }
+                } finally {
+                    connection?.disconnect()
+                }
+
+                if (responseCode !in 200..299) {
+                    val apiMessage = ApiClientUtils.extractApiErrorMessage(body)
+                    return@withContext when (responseCode) {
+                        429 -> Result.failure(Exception("Rate limited. Please try again later."))
+                        400, 403 -> Result.failure(Exception(
+                            apiMessage.ifEmpty { "Invalid API key" }))
+                        else -> Result.failure(Exception(
+                            "Error $responseCode: ${apiMessage.ifEmpty { "Unexpected error" }}"))
+                    }
+                }
+
+                collected.addAll(parseModelsJson(body))
+                pages++
+                pageToken = try {
+                    JSONObject(body).optString("nextPageToken", "")
+                } catch (_: Exception) {
+                    ""
+                }
+                if (pageToken.isNullOrEmpty() || pages >= MAX_LIST_PAGES) break
+            }
+            Result.success(collected.toList())
+        } catch (e: Exception) {
+            Result.failure(e)
         }
     }
 

--- a/app/src/main/java/com/musheer360/swiftslate/manager/CommandManager.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/manager/CommandManager.kt
@@ -65,7 +65,7 @@ class CommandManager(context: Context) {
         "cut" to "Cut the text to clipboard.",
         "paste" to "Paste from clipboard.",
         "replace" to "Replace text with clipboard content.",
-        "translate:XX" to "Translate text to any language code (e.g. ?translate:es, ?translate:fr)."
+        "translate:xx" to "Translate text to any language code (e.g. ?translate:es, ?translate:fr)."
     )
 
     // Default AI commands — seeded into custom commands on first run so users can edit/delete them
@@ -312,7 +312,7 @@ class CommandManager(context: Context) {
     fun findCommand(text: String): Command? {
         val commands = getCommands()
         for (cmd in commands) {  // Already sorted by trigger length in getCommands()
-            if (cmd.trigger.endsWith("translate:XX")) continue
+            if (cmd.trigger.endsWith("translate:xx")) continue
             if (text.endsWith(cmd.trigger)) {
                 return cmd
             }

--- a/app/src/main/java/com/musheer360/swiftslate/manager/CommandManager.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/manager/CommandManager.kt
@@ -64,7 +64,8 @@ class CommandManager(context: Context) {
         "copy" to "Copy the text to clipboard.",
         "cut" to "Cut the text to clipboard.",
         "paste" to "Paste from clipboard.",
-        "replace" to "Replace text with clipboard content."
+        "replace" to "Replace text with clipboard content.",
+        "translate:XX" to "Translate text to any language code (e.g. ?translate:es, ?translate:fr)."
     )
 
     // Default AI commands — seeded into custom commands on first run so users can edit/delete them
@@ -311,6 +312,7 @@ class CommandManager(context: Context) {
     fun findCommand(text: String): Command? {
         val commands = getCommands()
         for (cmd in commands) {  // Already sorted by trigger length in getCommands()
+            if (cmd.trigger.endsWith("translate:XX")) continue
             if (text.endsWith(cmd.trigger)) {
                 return cmd
             }

--- a/app/src/main/java/com/musheer360/swiftslate/manager/ProviderModelsCache.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/manager/ProviderModelsCache.kt
@@ -1,0 +1,34 @@
+package com.musheer360.swiftslate.manager
+
+import com.musheer360.swiftslate.model.ProviderType
+
+/**
+ * Process-lifetime cache of the model lists fetched from the Gemini and Groq
+ * /models endpoints for the dynamic Settings dropdowns (issue #148).
+ *
+ * Session-only by design — never written to prefs — so a stale provider catalog
+ * can never outlive this app process, matching how the Custom provider keeps its
+ * fetched list in composition state. [Entry.attempted] records whether a real
+ * fetch already ran this session (success or failure), so entering Settings
+ * again never auto-refires it; only lack of an API key leaves [attempted] false,
+ * letting the automatic fetch run once a key is added.
+ */
+object ProviderModelsCache {
+    data class Entry(val models: List<String>, val attempted: Boolean)
+
+    @Volatile private var gemini: Entry? = null
+    @Volatile private var groq: Entry? = null
+
+    fun get(type: String): Entry? = when (type) {
+        ProviderType.GEMINI -> gemini
+        ProviderType.GROQ -> groq
+        else -> null
+    }
+
+    fun put(type: String, entry: Entry) {
+        when (type) {
+            ProviderType.GEMINI -> gemini = entry
+            ProviderType.GROQ -> groq = entry
+        }
+    }
+}

--- a/app/src/main/java/com/musheer360/swiftslate/model/GeminiModels.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/model/GeminiModels.kt
@@ -1,10 +1,13 @@
 package com.musheer360.swiftslate.model
 
 /**
- * Catalog of the Gemini models SwiftSlate offers and how each is tuned. Mirrors
- * [GroqModels]: each model is defined once in [SPECS] together with its thinking
- * level, and the dropdown list, default, validation, and per-model thinking
- * level all derive from that single table.
+ * Catalog of the Gemini models SwiftSlate curates and how each is tuned. Mirrors
+ * [GroqModels]: each curated model is defined once in [SPECS] together with its
+ * thinking level, and the default, display labels, and per-model thinking level
+ * all derive from that single table. Since issue #148 the Settings dropdown no
+ * longer renders from this table — it lists whatever the provider's /models
+ * endpoint returns (see [ProviderModelsCache]); SPECS remains the source for
+ * defaults, friendly names, and thinking levels.
  *
  * Thinking control on Gemini 3.x is via generationConfig.thinkingConfig.thinkingLevel
  * (a string enum), kept per model here (spec-driven) rather than hardcoded in the
@@ -36,18 +39,27 @@ object GeminiModels {
     /** Model IDs, in display order (used for validation and by the provider config). */
     val ALL: List<String> = SPECS.map { it.id }
 
-    /** (id, label) pairs for the Settings dropdown — shows a friendly name, stores the id. */
-    val OPTIONS: List<Pair<String, String>> = SPECS.map { it.id to it.label }
+    /**
+     * Ids that Google has withdrawn and must migrate to [DEFAULT] rather than pass
+     * through — requests with them fail for (at least) newer accounts, so keeping
+     * one selected would break every command (issue #113 precedent). Unknown ids
+     * that are NOT listed here belong to models fetched dynamically off the live
+     * /models endpoint (issue #148) and are kept verbatim.
+     */
+    private val RETIRED_IDS: Set<String> = setOf("gemini-2.5-flash-lite")
 
     /** Friendly display label for [model]; falls back to the id if unknown. */
     fun label(model: String): String = SPECS.firstOrNull { it.id == model }?.label ?: model
 
     /**
-     * Coerce a stored/selected model to a currently-supported one. This migrates
-     * users off retired ids (e.g. gemini-2.5-flash-lite, which is no longer
-     * available to new users) to [DEFAULT].
+     * Normalize a stored/selected model value. Dynamic selection (issue #148) means
+     * any id the API accepts may be stored, so unknown ids pass through trimmed;
+     * only blank values and known-retired ids coerce to [DEFAULT].
      */
-    fun sanitize(value: String?): String = if (value in ALL) value!! else DEFAULT
+    fun sanitize(value: String?): String {
+        val trimmed = value?.trim().orEmpty()
+        return if (trimmed.isEmpty() || trimmed in RETIRED_IDS) DEFAULT else trimmed
+    }
 
     /**
      * Thinking level to request for [model] via generationConfig.thinkingConfig,

--- a/app/src/main/java/com/musheer360/swiftslate/model/GroqModels.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/model/GroqModels.kt
@@ -1,14 +1,18 @@
 package com.musheer360.swiftslate.model
 
 /**
- * Single source of truth for the Groq models SwiftSlate offers and how each one
+ * Single source of truth for the Groq models SwiftSlate curates and how each one
  * is driven with respect to reasoning ("thinking").
  *
- * Each offered model is defined once in [SPECS] together with the reasoning
- * parameters it needs. The dropdown list, the default, validation, and the
- * per-model reasoning params all derive from that single table, so adding or
- * removing a model is a one-line change that forces you to state its reasoning
- * behavior right there.
+ * Each curated model is defined once in [SPECS] together with the reasoning
+ * parameters it needs. The default, display labels, and the per-model reasoning
+ * params all derive from that single table, so adding or removing a model is a
+ * one-line change that forces you to state its reasoning behavior right there.
+ * Since issue #148 the Settings dropdown no longer renders from this table — it
+ * lists whatever Groq's /models endpoint returns (see [ProviderModelsCache]);
+ * SPECS remains the source for defaults, friendly names, and reasoning params.
+ * Off-catalog models picked from that dynamic list send no reasoning params
+ * ([reasoningParams] returns empty for unknown ids), which every model accepts.
  *
  * Reasoning support on Groq is per-model and strictly validated by the API:
  * sending an unsupported reasoning parameter (or an unsupported value) returns
@@ -60,14 +64,40 @@ object GroqModels {
     /** Model IDs, in display order (used for validation and by the provider config). */
     val ALL: List<String> = SPECS.map { it.id }
 
-    /** (id, label) pairs for the Settings dropdown — shows a friendly name, stores the id. */
-    val OPTIONS: List<Pair<String, String>> = SPECS.map { it.id to it.label }
+    /**
+     * Ids Groq has decommissioned; they must migrate to [DEFAULT] rather than pass
+     * through, because requests with them always fail. Unknown ids NOT listed here
+     * come from the dynamic /models list (issue #148) and are kept verbatim.
+     */
+    private val RETIRED_IDS: Set<String> = setOf(
+        "llama-3.3-70b-versatile",
+        "llama-4-scout",
+        "meta-llama/llama-4-scout-17b-16e-instruct"
+    )
+
+    /**
+     * Groq's /models endpoint also serves entries that cannot run text-transforming
+     * chat completions: Whisper transcription, PlayAI TTS, and Llama Guard safety
+     * classifiers. Conservative substring exclusions, verified against the live
+     * catalog; anything unrecognized stays listed (fail-open).
+     */
+    private val NON_CHAT_SUBSTRINGS = listOf("whisper", "-tts", "guard", "playai")
+
+    fun isChatCandidate(id: String): Boolean =
+        NON_CHAT_SUBSTRINGS.none { id.contains(it, ignoreCase = true) }
 
     /** Friendly display label for [model]; falls back to the id if unknown. */
     fun label(model: String): String = SPECS.firstOrNull { it.id == model }?.label ?: model
 
-    /** Coerce a stored/selected model to a currently-supported one. */
-    fun sanitize(value: String?): String = if (value in ALL) value!! else DEFAULT
+    /**
+     * Normalize a stored/selected model value. Dynamic selection (issue #148) means
+     * any id the API accepts may be stored, so unknown ids pass through trimmed;
+     * only blank values and known-retired ids coerce to [DEFAULT].
+     */
+    fun sanitize(value: String?): String {
+        val trimmed = value?.trim().orEmpty()
+        return if (trimmed.isEmpty() || trimmed in RETIRED_IDS) DEFAULT else trimmed
+    }
 
     /**
      * Reasoning parameters to merge into a Groq chat-completions request body for

--- a/app/src/main/java/com/musheer360/swiftslate/ui/CommandsScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/CommandsScreen.kt
@@ -51,7 +51,8 @@ fun CommandsScreen(commandManager: CommandManager) {
     var commands by remember { mutableStateOf(commandManager.getCommands()) }
     val displayCommands = remember(commands) {
         val (builtIn, custom) = commands.partition { it.isBuiltIn }
-        builtIn + custom
+        val (translateCmd, otherBuiltIns) = builtIn.partition { it.trigger.endsWith("translate:xx") }
+        otherBuiltIns + translateCmd + custom
     }
     var trigger by rememberSaveable { mutableStateOf("") }
     var prompt by rememberSaveable { mutableStateOf("") }

--- a/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
@@ -251,7 +251,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
         ScreenTitle(stringResource(R.string.settings_title))
 
         // Card 1: Provider + Model
-        SlateCard(contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp)) {
+        SlateCard {
             Text(
                 text = stringResource(R.string.settings_provider_title),
                 fontSize = 13.sp,
@@ -564,13 +564,12 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     inactiveTrackColor = MaterialTheme.colorScheme.outline
                 )
             )
-            Spacer(modifier = Modifier.height(4.dp))
         }
 
         Spacer(modifier = Modifier.height(6.dp))
 
         // Card 2: Trigger Prefix
-        SlateCard(contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp)) {
+        SlateCard {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -615,7 +614,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
         Spacer(modifier = Modifier.height(6.dp))
 
         // Card 3: Backup
-        SlateCard(contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp)) {
+        SlateCard {
             Text(
                 text = stringResource(R.string.backup_desc),
                 fontSize = 13.sp,
@@ -662,18 +661,14 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
         Spacer(modifier = Modifier.height(6.dp))
 
         // Card 4: About
-        SlateCard(
-            modifier = Modifier.weight(1f),
-            fillHeight = true,
-            contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp)
-        ) {
+        SlateCard(modifier = Modifier.weight(1f), fillHeight = true) {
             Text(
                 text = stringResource(R.string.app_name) + " v" + BuildConfig.VERSION_NAME,
                 fontSize = 15.sp,
                 fontWeight = FontWeight.Medium,
                 color = MaterialTheme.colorScheme.onSurface
             )
-            Spacer(modifier = Modifier.height(2.dp))
+            Spacer(modifier = Modifier.height(3.dp))
             Text(
                 text = stringResource(R.string.settings_check_updates),
                 fontSize = 13.sp,
@@ -682,17 +677,15 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     uriHandler.openUri("https://github.com/Musheer360/SwiftSlate/releases/latest")
                 }
             )
-            Spacer(modifier = Modifier.weight(1f, fill = false))
-            Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.weight(1f))
             SlateDivider()
-            Spacer(modifier = Modifier.height(4.dp))
-            Spacer(modifier = Modifier.weight(1f, fill = false))
+            Spacer(modifier = Modifier.weight(1f))
             Text(
                 text = stringResource(R.string.settings_made_by),
                 fontSize = 13.sp,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Spacer(modifier = Modifier.height(2.dp))
+            Spacer(modifier = Modifier.height(3.dp))
             Text(
                 text = stringResource(R.string.settings_sponsor),
                 fontSize = 13.sp,

--- a/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
@@ -146,9 +146,9 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 result.isSuccess -> String.format(modelsLoadedMsg, models.size)
                 else -> modelsLoadFailedMsg
             }
-            if (success) {
-                ProviderModelsCache.put(type, ProviderModelsCache.Entry(models, attempted = true))
-            }
+            val currentModels = if (isGemini) geminiModelList else groqModelList
+            val toCache = if (success) models else (ProviderModelsCache.get(type)?.models ?: currentModels)
+            ProviderModelsCache.put(type, ProviderModelsCache.Entry(toCache, attempted = true))
             if (isGemini) {
                 isFetchingGeminiModels = false
                 if (success) geminiModelList = models
@@ -824,7 +824,7 @@ private fun DynamicModelDropdown(
                 DropdownMenuItem(
                     text = {
                         Text(
-                            text = if (!enabled) needKeyText else stringResource(R.string.settings_fetch_models_empty),
+                            text = if (!enabled) needKeyText else stringResource(R.string.settings_models_empty_provider),
                             fontSize = 13.sp,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )

--- a/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
@@ -62,12 +62,12 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
     var selectedModel by remember { mutableStateOf(GeminiModels.sanitize(prefs.getString(PrefKeys.GEMINI_MODEL, GeminiModels.DEFAULT))) }
     var modelExpanded by remember { mutableStateOf(false) }
     // Dynamic model lists (issue #148): fetched from each provider's live /models
-    // endpoint, seeded from the process-lifetime cache so tab switches don't refetch.
-    var geminiModelList by remember { mutableStateOf(ProviderModelsCache.get(ProviderType.GEMINI)?.models ?: emptyList()) }
+    // endpoint, seeded from the process-lifetime cache or curated defaults as initial fallback.
+    var geminiModelList by remember { mutableStateOf(ProviderModelsCache.get(ProviderType.GEMINI)?.models ?: GeminiModels.ALL) }
 
     var groqModel by remember { mutableStateOf(GroqModels.sanitize(prefs.getString(PrefKeys.GROQ_MODEL, GroqModels.DEFAULT))) }
     var groqModelExpanded by remember { mutableStateOf(false) }
-    var groqModelList by remember { mutableStateOf(ProviderModelsCache.get(ProviderType.GROQ)?.models ?: emptyList()) }
+    var groqModelList by remember { mutableStateOf(ProviderModelsCache.get(ProviderType.GROQ)?.models ?: GroqModels.ALL) }
 
     var customEndpoint by rememberSaveable { mutableStateOf(prefs.getString(PrefKeys.CUSTOM_ENDPOINT, "") ?: "") }
     var customModel by rememberSaveable { mutableStateOf(prefs.getString(PrefKeys.CUSTOM_MODEL, "") ?: "") }
@@ -146,17 +146,17 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 result.isSuccess -> String.format(modelsLoadedMsg, models.size)
                 else -> modelsLoadFailedMsg
             }
-            // Attempted=true even on failure: the automatic fetch must not re-fire;
-            // only an explicit Refresh/Retry (or a fresh session) tries again.
-            ProviderModelsCache.put(type, ProviderModelsCache.Entry(models, attempted = true))
+            if (success) {
+                ProviderModelsCache.put(type, ProviderModelsCache.Entry(models, attempted = true))
+            }
             if (isGemini) {
                 isFetchingGeminiModels = false
-                geminiModelList = models
+                if (success) geminiModelList = models
                 geminiFetchSuccess = success
                 geminiFetchMessage = message
             } else {
                 isFetchingGroqModels = false
-                groqModelList = models
+                if (success) groqModelList = models
                 groqFetchSuccess = success
                 groqFetchMessage = message
             }
@@ -328,7 +328,12 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     selectedLabel = GeminiModels.label(selectedModel),
                     enabled = apiKeys.isNotEmpty(),
                     expanded = modelExpanded,
-                    onExpandedChange = { modelExpanded = it },
+                    onExpandedChange = { isOpening ->
+                        modelExpanded = isOpening
+                        if (isOpening && apiKeys.isNotEmpty() && !isFetchingGeminiModels) {
+                            startModelFetch(ProviderType.GEMINI)
+                        }
+                    },
                     models = geminiModelList,
                     labelFor = { GeminiModels.label(it) },
                     onSelect = { id ->
@@ -338,7 +343,9 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                         modelExpanded = false
                     },
                     onDismiss = { modelExpanded = false },
-                    isFetching = isFetchingGeminiModels
+                    isFetching = isFetchingGeminiModels,
+                    fetchingText = fetchingModelsMsg,
+                    needKeyText = modelsNeedKeyMsg
                 )
                 ModelFetchStatusRow(
                     enabled = apiKeys.isNotEmpty(),
@@ -364,7 +371,12 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     selectedLabel = GroqModels.label(groqModel),
                     enabled = apiKeys.isNotEmpty(),
                     expanded = groqModelExpanded,
-                    onExpandedChange = { groqModelExpanded = it },
+                    onExpandedChange = { isOpening ->
+                        groqModelExpanded = isOpening
+                        if (isOpening && apiKeys.isNotEmpty() && !isFetchingGroqModels) {
+                            startModelFetch(ProviderType.GROQ)
+                        }
+                    },
                     models = groqModelList,
                     labelFor = { GroqModels.label(it) },
                     onSelect = { id ->
@@ -374,7 +386,9 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                         groqModelExpanded = false
                     },
                     onDismiss = { groqModelExpanded = false },
-                    isFetching = isFetchingGroqModels
+                    isFetching = isFetchingGroqModels,
+                    fetchingText = fetchingModelsMsg,
+                    needKeyText = modelsNeedKeyMsg
                 )
                 ModelFetchStatusRow(
                     enabled = apiKeys.isNotEmpty(),
@@ -744,9 +758,9 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
 
 /**
  * Read-only dropdown listing one provider's dynamically fetched model ids
- * (issue #148). Opens only when a key exists, no fetch is in flight, and at
- * least one model was fetched; the menu caps its height and scrolls so long
- * provider catalogs stay usable.
+ * (issue #148). Opens immediately showing cached or fallback models,
+ * triggers a real-time fetch when opened, and caps its height with vertical
+ * scroll so long provider catalogs stay usable.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -759,12 +773,13 @@ private fun DynamicModelDropdown(
     labelFor: (String) -> String,
     onSelect: (String) -> Unit,
     onDismiss: () -> Unit,
-    isFetching: Boolean
+    isFetching: Boolean,
+    fetchingText: String,
+    needKeyText: String
 ) {
-    val openable = enabled && !isFetching && models.isNotEmpty()
     ExposedDropdownMenuBox(
-        expanded = expanded && openable,
-        onExpandedChange = { if (openable) onExpandedChange(it) }
+        expanded = expanded,
+        onExpandedChange = onExpandedChange
     ) {
         SlateTextField(
             value = selectedLabel,
@@ -775,16 +790,65 @@ private fun DynamicModelDropdown(
         ExposedDropdownMenu(
             containerColor = MaterialTheme.colorScheme.surface,
             shape = RoundedCornerShape(10.dp),
-            expanded = expanded && openable,
+            expanded = expanded,
             onDismissRequest = onDismiss,
             // Provider catalogs can exceed a hundred entries — cap and scroll.
-            modifier = Modifier.heightIn(max = 320.dp)
+            modifier = Modifier.heightIn(max = 300.dp)
         ) {
-            models.forEach { id ->
+            if (isFetching) {
                 DropdownMenuItem(
-                    text = { Text(labelFor(id)) },
-                    onClick = { onSelect(id) }
+                    text = {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                        ) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(16.dp),
+                                strokeWidth = 2.dp,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                            Spacer(modifier = Modifier.width(10.dp))
+                            Text(
+                                text = fetchingText,
+                                fontSize = 13.sp,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    },
+                    onClick = {},
+                    enabled = false
                 )
+                SlateDivider()
+            }
+            if (models.isEmpty() && !isFetching) {
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = if (!enabled) needKeyText else stringResource(R.string.settings_fetch_models_empty),
+                            fontSize = 13.sp,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    },
+                    onClick = {},
+                    enabled = false
+                )
+            } else {
+                models.forEach { id ->
+                    val displayLabel = labelFor(id)
+                    DropdownMenuItem(
+                        text = {
+                            Text(
+                                text = displayLabel,
+                                color = if (displayLabel == selectedLabel || id == selectedLabel) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    MaterialTheme.colorScheme.onSurface
+                                }
+                            )
+                        },
+                        onClick = { onSelect(id) }
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
@@ -59,15 +59,13 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
     var providerType by remember { mutableStateOf(prefs.getString(PrefKeys.PROVIDER_TYPE, ProviderType.GEMINI) ?: ProviderType.GEMINI) }
     var providerExpanded by remember { mutableStateOf(false) }
 
-    var selectedModel by remember { mutableStateOf(GeminiModels.sanitize(prefs.getString(PrefKeys.GEMINI_MODEL, GeminiModels.DEFAULT))) }
+    var selectedModel by remember { mutableStateOf(prefs.getString(PrefKeys.GEMINI_MODEL, "") ?: "") }
     var modelExpanded by remember { mutableStateOf(false) }
-    // Dynamic model lists (issue #148): fetched from each provider's live /models
-    // endpoint, seeded from the process-lifetime cache or curated defaults as initial fallback.
-    var geminiModelList by remember { mutableStateOf(ProviderModelsCache.get(ProviderType.GEMINI)?.models ?: GeminiModels.ALL) }
+    var geminiModelList by remember { mutableStateOf(ProviderModelsCache.get(ProviderType.GEMINI)?.models ?: emptyList()) }
 
-    var groqModel by remember { mutableStateOf(GroqModels.sanitize(prefs.getString(PrefKeys.GROQ_MODEL, GroqModels.DEFAULT))) }
+    var groqModel by remember { mutableStateOf(prefs.getString(PrefKeys.GROQ_MODEL, "") ?: "") }
     var groqModelExpanded by remember { mutableStateOf(false) }
-    var groqModelList by remember { mutableStateOf(ProviderModelsCache.get(ProviderType.GROQ)?.models ?: GroqModels.ALL) }
+    var groqModelList by remember { mutableStateOf(ProviderModelsCache.get(ProviderType.GROQ)?.models ?: emptyList()) }
 
     var customEndpoint by rememberSaveable { mutableStateOf(prefs.getString(PrefKeys.CUSTOM_ENDPOINT, "") ?: "") }
     var customModel by rememberSaveable { mutableStateOf(prefs.getString(PrefKeys.CUSTOM_MODEL, "") ?: "") }
@@ -80,11 +78,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
     var fetchMessage by remember { mutableStateOf<String?>(null) }
     var fetchSuccess by remember { mutableStateOf(false) }
     var isFetchingGeminiModels by remember { mutableStateOf(false) }
-    var geminiFetchMessage by remember { mutableStateOf<String?>(null) }
-    var geminiFetchSuccess by remember { mutableStateOf(false) }
     var isFetchingGroqModels by remember { mutableStateOf(false) }
-    var groqFetchMessage by remember { mutableStateOf<String?>(null) }
-    var groqFetchSuccess by remember { mutableStateOf(false) }
     var apiKeys by remember { mutableStateOf<List<String>>(emptyList()) }
     val openAIClient = remember { OpenAICompatibleClient() }
     val geminiClient = remember { GeminiClient() }
@@ -104,10 +98,6 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
     val modelsEmptyMsg = stringResource(R.string.settings_fetch_models_empty)
     val modelsFailedMsg = stringResource(R.string.settings_fetch_models_failed)
     val signinRequiredMsg = stringResource(R.string.error_provider_auth_required)
-    val modelsRefreshMsg = stringResource(R.string.settings_models_refresh)
-    val modelsNeedKeyMsg = stringResource(R.string.settings_models_need_key)
-    val modelsLoadFailedMsg = stringResource(R.string.settings_models_load_failed)
-    val modelsEmptyProviderMsg = stringResource(R.string.settings_models_empty_provider)
 
     // Registered keys are decrypted through the Keystore — load off the main thread, as
     // KeysScreen does. The first key is sent as Bearer when fetching models; keyless local
@@ -141,24 +131,27 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
             }
             val models = result.getOrNull().orEmpty()
             val success = result.isSuccess && models.isNotEmpty()
-            val message = when {
-                result.isSuccess && models.isEmpty() -> modelsEmptyProviderMsg
-                result.isSuccess -> String.format(modelsLoadedMsg, models.size)
-                else -> modelsLoadFailedMsg
-            }
             val currentModels = if (isGemini) geminiModelList else groqModelList
             val toCache = if (success) models else (ProviderModelsCache.get(type)?.models ?: currentModels)
             ProviderModelsCache.put(type, ProviderModelsCache.Entry(toCache, attempted = true))
             if (isGemini) {
                 isFetchingGeminiModels = false
-                if (success) geminiModelList = models
-                geminiFetchSuccess = success
-                geminiFetchMessage = message
+                if (success) {
+                    geminiModelList = models
+                    if (selectedModel.isBlank() && models.isNotEmpty()) {
+                        selectedModel = models.first()
+                        prefs.edit().putString(PrefKeys.GEMINI_MODEL, models.first()).apply()
+                    }
+                }
             } else {
                 isFetchingGroqModels = false
-                if (success) groqModelList = models
-                groqFetchSuccess = success
-                groqFetchMessage = message
+                if (success) {
+                    groqModelList = models
+                    if (groqModel.isBlank() && models.isNotEmpty()) {
+                        groqModel = models.first()
+                        prefs.edit().putString(PrefKeys.GROQ_MODEL, models.first()).apply()
+                    }
+                }
             }
         }
     }
@@ -322,10 +315,9 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     fontSize = 13.sp,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                Spacer(modifier = Modifier.height(8.dp))
-                // Dynamic list (issue #148): fetched from the live /models endpoint.
+                Spacer(modifier = Modifier.height(6.dp))
                 DynamicModelDropdown(
-                    selectedLabel = GeminiModels.label(selectedModel),
+                    selectedLabel = if (apiKeys.isEmpty() || selectedModel.isBlank()) "" else GeminiModels.label(selectedModel),
                     enabled = apiKeys.isNotEmpty(),
                     expanded = modelExpanded,
                     onExpandedChange = { isOpening ->
@@ -344,21 +336,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     },
                     onDismiss = { modelExpanded = false },
                     isFetching = isFetchingGeminiModels,
-                    fetchingText = fetchingModelsMsg,
-                    needKeyText = modelsNeedKeyMsg
-                )
-                ModelFetchStatusRow(
-                    enabled = apiKeys.isNotEmpty(),
-                    isFetching = isFetchingGeminiModels,
-                    fetchingText = fetchingModelsMsg,
-                    needKeyText = modelsNeedKeyMsg,
-                    refreshText = modelsRefreshMsg,
-                    message = geminiFetchMessage,
-                    success = geminiFetchSuccess,
-                    onRefresh = {
-                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                        startModelFetch(ProviderType.GEMINI)
-                    }
+                    fetchingText = fetchingModelsMsg
                 )
             } else if (providerType == ProviderType.GROQ) {
                 Text(
@@ -366,9 +344,9 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     fontSize = 13.sp,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(6.dp))
                 DynamicModelDropdown(
-                    selectedLabel = GroqModels.label(groqModel),
+                    selectedLabel = if (apiKeys.isEmpty() || groqModel.isBlank()) "" else GroqModels.label(groqModel),
                     enabled = apiKeys.isNotEmpty(),
                     expanded = groqModelExpanded,
                     onExpandedChange = { isOpening ->
@@ -387,23 +365,8 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     },
                     onDismiss = { groqModelExpanded = false },
                     isFetching = isFetchingGroqModels,
-                    fetchingText = fetchingModelsMsg,
-                    needKeyText = modelsNeedKeyMsg
+                    fetchingText = fetchingModelsMsg
                 )
-                ModelFetchStatusRow(
-                    enabled = apiKeys.isNotEmpty(),
-                    isFetching = isFetchingGroqModels,
-                    fetchingText = fetchingModelsMsg,
-                    needKeyText = modelsNeedKeyMsg,
-                    refreshText = modelsRefreshMsg,
-                    message = groqFetchMessage,
-                    success = groqFetchSuccess,
-                    onRefresh = {
-                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                        startModelFetch(ProviderType.GROQ)
-                    }
-                )
-
             } else {
                 Text(
                     text = stringResource(R.string.settings_endpoint_title),
@@ -579,7 +542,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     color = MaterialTheme.colorScheme.onSurface
                 )
             }
-            Spacer(modifier = Modifier.height(10.dp))
+            Spacer(modifier = Modifier.height(6.dp))
             Slider(
                 value = temperature,
                 onValueChange = {
@@ -594,7 +557,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 },
                 valueRange = 0f..2f,
                 steps = 19,
-                modifier = Modifier.fillMaxWidth().height(26.dp),
+                modifier = Modifier.fillMaxWidth().height(24.dp),
                 colors = SliderDefaults.colors(
                     thumbColor = MaterialTheme.colorScheme.primary,
                     activeTrackColor = MaterialTheme.colorScheme.primary,
@@ -658,7 +621,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 fontSize = 13.sp,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(8.dp))
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
@@ -670,7 +633,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                         exportLauncher.launch("swiftslate-commands.json")
                     },
                     shape = RoundedCornerShape(10.dp),
-                    modifier = Modifier.weight(1f).heightIn(min = 48.dp)
+                    modifier = Modifier.weight(1f).heightIn(min = 44.dp)
                 ) {
                     Text(stringResource(R.string.backup_export))
                 }
@@ -681,7 +644,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                         showImportConfirm = true
                     },
                     shape = RoundedCornerShape(10.dp),
-                    modifier = Modifier.weight(1f).heightIn(min = 48.dp)
+                    modifier = Modifier.weight(1f).heightIn(min = 44.dp)
                 ) {
                     Text(stringResource(R.string.backup_import))
                 }
@@ -706,7 +669,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 fontWeight = FontWeight.Medium,
                 color = MaterialTheme.colorScheme.onSurface
             )
-            Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(2.dp))
             Text(
                 text = stringResource(R.string.settings_check_updates),
                 fontSize = 13.sp,
@@ -715,15 +678,17 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     uriHandler.openUri("https://github.com/Musheer360/SwiftSlate/releases/latest")
                 }
             )
-            Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.weight(1f, fill = false))
+            Spacer(modifier = Modifier.height(6.dp))
             SlateDivider()
-            Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.height(6.dp))
+            Spacer(modifier = Modifier.weight(1f, fill = false))
             Text(
                 text = stringResource(R.string.settings_made_by),
                 fontSize = 13.sp,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(2.dp))
             Text(
                 text = stringResource(R.string.settings_sponsor),
                 fontSize = 13.sp,
@@ -758,9 +723,9 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
 
 /**
  * Read-only dropdown listing one provider's dynamically fetched model ids
- * (issue #148). Opens immediately showing cached or fallback models,
- * triggers a real-time fetch when opened, and caps its height with vertical
- * scroll so long provider catalogs stay usable.
+ * (issue #148). Opens immediately showing cached or live models, triggers
+ * real-time fetch when opened, and caps its height with vertical scroll
+ * so long provider catalogs stay usable.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -774,12 +739,11 @@ private fun DynamicModelDropdown(
     onSelect: (String) -> Unit,
     onDismiss: () -> Unit,
     isFetching: Boolean,
-    fetchingText: String,
-    needKeyText: String
+    fetchingText: String
 ) {
     ExposedDropdownMenuBox(
-        expanded = expanded,
-        onExpandedChange = onExpandedChange
+        expanded = expanded && enabled,
+        onExpandedChange = { if (enabled) onExpandedChange(it) }
     ) {
         SlateTextField(
             value = selectedLabel,
@@ -787,52 +751,42 @@ private fun DynamicModelDropdown(
             readOnly = true,
             modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
         )
-        ExposedDropdownMenu(
-            containerColor = MaterialTheme.colorScheme.surface,
-            shape = RoundedCornerShape(10.dp),
-            expanded = expanded,
-            onDismissRequest = onDismiss,
-            // Provider catalogs can exceed a hundred entries — cap and scroll.
-            modifier = Modifier.heightIn(max = 300.dp)
-        ) {
-            if (isFetching) {
-                DropdownMenuItem(
-                    text = {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
-                        ) {
-                            CircularProgressIndicator(
-                                modifier = Modifier.size(16.dp),
-                                strokeWidth = 2.dp,
-                                color = MaterialTheme.colorScheme.primary
-                            )
-                            Spacer(modifier = Modifier.width(10.dp))
-                            Text(
-                                text = fetchingText,
-                                fontSize = 13.sp,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    },
-                    onClick = {},
-                    enabled = false
-                )
-                SlateDivider()
-            }
-            if (models.isEmpty() && !isFetching) {
-                DropdownMenuItem(
-                    text = {
-                        Text(
-                            text = if (!enabled) needKeyText else stringResource(R.string.settings_models_empty_provider),
-                            fontSize = 13.sp,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    },
-                    onClick = {},
-                    enabled = false
-                )
-            } else {
+        if (enabled && expanded) {
+            ExposedDropdownMenu(
+                containerColor = MaterialTheme.colorScheme.surface,
+                shape = RoundedCornerShape(10.dp),
+                expanded = expanded,
+                onDismissRequest = onDismiss,
+                // Provider catalogs can exceed a hundred entries — cap and scroll.
+                modifier = Modifier.heightIn(max = 300.dp)
+            ) {
+                if (isFetching) {
+                    DropdownMenuItem(
+                        text = {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                            ) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(16.dp),
+                                    strokeWidth = 2.dp,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                                Spacer(modifier = Modifier.width(10.dp))
+                                Text(
+                                    text = fetchingText,
+                                    fontSize = 13.sp,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        },
+                        onClick = {},
+                        enabled = false
+                    )
+                    if (models.isNotEmpty()) {
+                        SlateDivider()
+                    }
+                }
                 models.forEach { id ->
                     val displayLabel = labelFor(id)
                     DropdownMenuItem(
@@ -851,53 +805,5 @@ private fun DynamicModelDropdown(
                 }
             }
         }
-    }
-}
-
-/**
- * Status + action row under a dynamic model dropdown: a hint when no API key is
- * registered, a fetching indicator while the list loads, and a Refresh button to
- * re-pull on demand; any completed-fetch message renders beneath it.
- */
-@Composable
-private fun ModelFetchStatusRow(
-    enabled: Boolean,
-    isFetching: Boolean,
-    fetchingText: String,
-    needKeyText: String,
-    refreshText: String,
-    message: String?,
-    success: Boolean,
-    onRefresh: () -> Unit
-) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.End,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        val statusText = when {
-            !enabled -> needKeyText
-            isFetching -> fetchingText
-            else -> null
-        }
-        if (statusText != null) {
-            Text(
-                text = statusText,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontSize = 13.sp,
-                modifier = Modifier.weight(1f)
-            )
-        }
-        TextButton(onClick = onRefresh, enabled = enabled && !isFetching) {
-            Text(refreshText)
-        }
-    }
-    message?.let { msg ->
-        Text(
-            text = msg,
-            color = if (success) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.onSurfaceVariant,
-            fontSize = 13.sp,
-            modifier = Modifier.padding(top = 4.dp)
-        )
     }
 }

--- a/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
@@ -524,7 +524,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     )
                 }
             }
-            Spacer(modifier = Modifier.height(6.dp))
+            Spacer(modifier = Modifier.height(8.dp))
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically
@@ -542,7 +542,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     color = MaterialTheme.colorScheme.onSurface
                 )
             }
-            Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(8.dp))
             Slider(
                 value = temperature,
                 onValueChange = {
@@ -557,13 +557,14 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 },
                 valueRange = 0f..2f,
                 steps = 19,
-                modifier = Modifier.fillMaxWidth().height(24.dp),
+                modifier = Modifier.fillMaxWidth().height(26.dp),
                 colors = SliderDefaults.colors(
                     thumbColor = MaterialTheme.colorScheme.primary,
                     activeTrackColor = MaterialTheme.colorScheme.primary,
                     inactiveTrackColor = MaterialTheme.colorScheme.outline
                 )
             )
+            Spacer(modifier = Modifier.height(6.dp))
         }
 
         Spacer(modifier = Modifier.height(6.dp))

--- a/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
@@ -251,13 +251,13 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
         ScreenTitle(stringResource(R.string.settings_title))
 
         // Card 1: Provider + Model
-        SlateCard {
+        SlateCard(contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp)) {
             Text(
                 text = stringResource(R.string.settings_provider_title),
                 fontSize = 13.sp,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(4.dp))
             ExposedDropdownMenuBox(
                 expanded = providerExpanded,
                 onExpandedChange = { providerExpanded = !providerExpanded }
@@ -308,14 +308,14 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     )
                 }
             }
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(6.dp))
             if (providerType == ProviderType.GEMINI) {
                 Text(
                     text = stringResource(R.string.settings_model_title),
                     fontSize = 13.sp,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                Spacer(modifier = Modifier.height(6.dp))
+                Spacer(modifier = Modifier.height(4.dp))
                 DynamicModelDropdown(
                     selectedLabel = if (apiKeys.isEmpty() || selectedModel.isBlank()) "" else GeminiModels.label(selectedModel),
                     enabled = apiKeys.isNotEmpty(),
@@ -524,7 +524,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     )
                 }
             }
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(6.dp))
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically
@@ -542,7 +542,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     color = MaterialTheme.colorScheme.onSurface
                 )
             }
-            Spacer(modifier = Modifier.height(6.dp))
+            Spacer(modifier = Modifier.height(4.dp))
             Slider(
                 value = temperature,
                 onValueChange = {
@@ -567,10 +567,10 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
             Spacer(modifier = Modifier.height(4.dp))
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(6.dp))
 
         // Card 2: Trigger Prefix
-        SlateCard {
+        SlateCard(contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp)) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -612,16 +612,16 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
             }
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(6.dp))
 
         // Card 3: Backup
-        SlateCard {
+        SlateCard(contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp)) {
             Text(
                 text = stringResource(R.string.backup_desc),
                 fontSize = 13.sp,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(6.dp))
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
@@ -633,7 +633,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                         exportLauncher.launch("swiftslate-commands.json")
                     },
                     shape = RoundedCornerShape(10.dp),
-                    modifier = Modifier.weight(1f).heightIn(min = 44.dp)
+                    modifier = Modifier.weight(1f).heightIn(min = 40.dp)
                 ) {
                     Text(stringResource(R.string.backup_export))
                 }
@@ -644,7 +644,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                         showImportConfirm = true
                     },
                     shape = RoundedCornerShape(10.dp),
-                    modifier = Modifier.weight(1f).heightIn(min = 44.dp)
+                    modifier = Modifier.weight(1f).heightIn(min = 40.dp)
                 ) {
                     Text(stringResource(R.string.backup_import))
                 }
@@ -659,10 +659,14 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
             }
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(6.dp))
 
         // Card 4: About
-        SlateCard(modifier = Modifier.weight(1f), fillHeight = true) {
+        SlateCard(
+            modifier = Modifier.weight(1f),
+            fillHeight = true,
+            contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp)
+        ) {
             Text(
                 text = stringResource(R.string.app_name) + " v" + BuildConfig.VERSION_NAME,
                 fontSize = 15.sp,
@@ -679,9 +683,9 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 }
             )
             Spacer(modifier = Modifier.weight(1f, fill = false))
-            Spacer(modifier = Modifier.height(6.dp))
+            Spacer(modifier = Modifier.height(4.dp))
             SlateDivider()
-            Spacer(modifier = Modifier.height(6.dp))
+            Spacer(modifier = Modifier.height(4.dp))
             Spacer(modifier = Modifier.weight(1f, fill = false))
             Text(
                 text = stringResource(R.string.settings_made_by),

--- a/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.sp
 import com.musheer360.swiftslate.BuildConfig
 import com.musheer360.swiftslate.R
 import com.musheer360.swiftslate.api.ApiClientUtils
+import com.musheer360.swiftslate.api.GeminiClient
 import com.musheer360.swiftslate.api.OpenAICompatibleClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -32,11 +33,13 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import com.musheer360.swiftslate.manager.CommandManager
 import com.musheer360.swiftslate.manager.KeyManager
+import com.musheer360.swiftslate.manager.ProviderModelsCache
 import com.musheer360.swiftslate.model.GeminiModels
 import com.musheer360.swiftslate.model.GroqModels
 import com.musheer360.swiftslate.model.PrefKeys
 import com.musheer360.swiftslate.model.ProviderType
 import com.musheer360.swiftslate.provider.EndpointValidator
+import com.musheer360.swiftslate.provider.GroqConfig
 import com.musheer360.swiftslate.ui.components.ScreenTitle
 import com.musheer360.swiftslate.ui.components.SlateCard
 import com.musheer360.swiftslate.ui.components.SlateDivider
@@ -58,11 +61,13 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
 
     var selectedModel by remember { mutableStateOf(GeminiModels.sanitize(prefs.getString(PrefKeys.GEMINI_MODEL, GeminiModels.DEFAULT))) }
     var modelExpanded by remember { mutableStateOf(false) }
-    val geminiModels = GeminiModels.OPTIONS
+    // Dynamic model lists (issue #148): fetched from each provider's live /models
+    // endpoint, seeded from the process-lifetime cache so tab switches don't refetch.
+    var geminiModelList by remember { mutableStateOf(ProviderModelsCache.get(ProviderType.GEMINI)?.models ?: emptyList()) }
 
     var groqModel by remember { mutableStateOf(GroqModels.sanitize(prefs.getString(PrefKeys.GROQ_MODEL, GroqModels.DEFAULT))) }
     var groqModelExpanded by remember { mutableStateOf(false) }
-    val groqModels = GroqModels.OPTIONS
+    var groqModelList by remember { mutableStateOf(ProviderModelsCache.get(ProviderType.GROQ)?.models ?: emptyList()) }
 
     var customEndpoint by rememberSaveable { mutableStateOf(prefs.getString(PrefKeys.CUSTOM_ENDPOINT, "") ?: "") }
     var customModel by rememberSaveable { mutableStateOf(prefs.getString(PrefKeys.CUSTOM_MODEL, "") ?: "") }
@@ -74,8 +79,15 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
     var isFetchingModels by remember { mutableStateOf(false) }
     var fetchMessage by remember { mutableStateOf<String?>(null) }
     var fetchSuccess by remember { mutableStateOf(false) }
+    var isFetchingGeminiModels by remember { mutableStateOf(false) }
+    var geminiFetchMessage by remember { mutableStateOf<String?>(null) }
+    var geminiFetchSuccess by remember { mutableStateOf(false) }
+    var isFetchingGroqModels by remember { mutableStateOf(false) }
+    var groqFetchMessage by remember { mutableStateOf<String?>(null) }
+    var groqFetchSuccess by remember { mutableStateOf(false) }
     var apiKeys by remember { mutableStateOf<List<String>>(emptyList()) }
     val openAIClient = remember { OpenAICompatibleClient() }
+    val geminiClient = remember { GeminiClient() }
 
     var triggerPrefix by remember { mutableStateOf(commandManager.getTriggerPrefix()) }
     var prefixError by remember { mutableStateOf<String?>(null) }
@@ -92,12 +104,75 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
     val modelsEmptyMsg = stringResource(R.string.settings_fetch_models_empty)
     val modelsFailedMsg = stringResource(R.string.settings_fetch_models_failed)
     val signinRequiredMsg = stringResource(R.string.error_provider_auth_required)
+    val modelsRefreshMsg = stringResource(R.string.settings_models_refresh)
+    val modelsNeedKeyMsg = stringResource(R.string.settings_models_need_key)
+    val modelsLoadFailedMsg = stringResource(R.string.settings_models_load_failed)
+    val modelsEmptyProviderMsg = stringResource(R.string.settings_models_empty_provider)
 
     // Registered keys are decrypted through the Keystore — load off the main thread, as
     // KeysScreen does. The first key is sent as Bearer when fetching models; keyless local
     // servers get no header at all.
     LaunchedEffect(Unit) {
         apiKeys = withContext(Dispatchers.IO) { keyManager.getKeys() }
+    }
+
+    // Fetches one provider's live model list (issue #148). Groq rides the existing
+    // OpenAI-compatible prober against its fixed endpoint; Gemini gets a native
+    // listing call. Results land in [ProviderModelsCache] plus local state so the
+    // dropdown renders without refetching on every visit.
+    fun startModelFetch(type: String) {
+        val isGemini = type == ProviderType.GEMINI
+        if (!isGemini && type != ProviderType.GROQ) return
+        if (isGemini && isFetchingGeminiModels) return
+        if (!isGemini && isFetchingGroqModels) return
+
+        val key = apiKeys.firstOrNull() ?: return
+
+        if (isGemini) isFetchingGeminiModels = true else isFetchingGroqModels = true
+        scope.launch {
+            val result = withContext(Dispatchers.IO) {
+                if (isGemini) {
+                    geminiClient.fetchModels(key)
+                } else {
+                    openAIClient.fetchModels(key, GroqConfig.ENDPOINT).map { ids ->
+                        ids.filter { GroqModels.isChatCandidate(it) }
+                    }
+                }
+            }
+            val models = result.getOrNull().orEmpty()
+            val success = result.isSuccess && models.isNotEmpty()
+            val message = when {
+                result.isSuccess && models.isEmpty() -> modelsEmptyProviderMsg
+                result.isSuccess -> String.format(modelsLoadedMsg, models.size)
+                else -> modelsLoadFailedMsg
+            }
+            // Attempted=true even on failure: the automatic fetch must not re-fire;
+            // only an explicit Refresh/Retry (or a fresh session) tries again.
+            ProviderModelsCache.put(type, ProviderModelsCache.Entry(models, attempted = true))
+            if (isGemini) {
+                isFetchingGeminiModels = false
+                geminiModelList = models
+                geminiFetchSuccess = success
+                geminiFetchMessage = message
+            } else {
+                isFetchingGroqModels = false
+                groqModelList = models
+                groqFetchSuccess = success
+                groqFetchMessage = message
+            }
+        }
+    }
+
+    // Auto-fetch once per session per provider (issue #148): fires when Settings shows
+    // a Gemini/Groq provider whose list has never been fetched this process — including
+    // the no-key case, so it runs automatically once a first key is added.
+    LaunchedEffect(providerType, apiKeys) {
+        if (providerType == ProviderType.GEMINI || providerType == ProviderType.GROQ) {
+            val cached = ProviderModelsCache.get(providerType)
+            if (apiKeys.isNotEmpty() && (cached == null || !cached.attempted)) {
+                startModelFetch(providerType)
+            }
+        }
     }
 
     var backupMessage by remember { mutableStateOf<String?>(null) }
@@ -248,36 +323,36 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Spacer(modifier = Modifier.height(8.dp))
-                ExposedDropdownMenuBox(
+                // Dynamic list (issue #148): fetched from the live /models endpoint.
+                DynamicModelDropdown(
+                    selectedLabel = GeminiModels.label(selectedModel),
+                    enabled = apiKeys.isNotEmpty(),
                     expanded = modelExpanded,
-                    onExpandedChange = { modelExpanded = !modelExpanded }
-                ) {
-                    SlateTextField(
-                        value = GeminiModels.label(selectedModel),
-                        onValueChange = {},
-                        readOnly = true,
-                        
-                        modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                    )
-                    ExposedDropdownMenu(
-                        containerColor = MaterialTheme.colorScheme.surface,
-                        shape = RoundedCornerShape(10.dp),
-                        expanded = modelExpanded,
-                        onDismissRequest = { modelExpanded = false }
-                    ) {
-                        geminiModels.forEach { (id, label) ->
-                            DropdownMenuItem(
-                                text = { Text(label) },
-                                onClick = {
-                                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                    selectedModel = id
-                                    prefs.edit().putString(PrefKeys.GEMINI_MODEL, id).remove(PrefKeys.STRUCTURED_OUTPUT_DISABLED_AT).apply()
-                                    modelExpanded = false
-                                }
-                            )
-                        }
+                    onExpandedChange = { modelExpanded = it },
+                    models = geminiModelList,
+                    labelFor = { GeminiModels.label(it) },
+                    onSelect = { id ->
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        selectedModel = id
+                        prefs.edit().putString(PrefKeys.GEMINI_MODEL, id).remove(PrefKeys.STRUCTURED_OUTPUT_DISABLED_AT).apply()
+                        modelExpanded = false
+                    },
+                    onDismiss = { modelExpanded = false },
+                    isFetching = isFetchingGeminiModels
+                )
+                ModelFetchStatusRow(
+                    enabled = apiKeys.isNotEmpty(),
+                    isFetching = isFetchingGeminiModels,
+                    fetchingText = fetchingModelsMsg,
+                    needKeyText = modelsNeedKeyMsg,
+                    refreshText = modelsRefreshMsg,
+                    message = geminiFetchMessage,
+                    success = geminiFetchSuccess,
+                    onRefresh = {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        startModelFetch(ProviderType.GEMINI)
                     }
-                }
+                )
             } else if (providerType == ProviderType.GROQ) {
                 Text(
                     text = stringResource(R.string.settings_model_title),
@@ -285,36 +360,36 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Spacer(modifier = Modifier.height(8.dp))
-                ExposedDropdownMenuBox(
+                DynamicModelDropdown(
+                    selectedLabel = GroqModels.label(groqModel),
+                    enabled = apiKeys.isNotEmpty(),
                     expanded = groqModelExpanded,
-                    onExpandedChange = { groqModelExpanded = !groqModelExpanded }
-                ) {
-                    SlateTextField(
-                        value = GroqModels.label(groqModel),
-                        onValueChange = {},
-                        readOnly = true,
-                        
-                        modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                    )
-                    ExposedDropdownMenu(
-                        containerColor = MaterialTheme.colorScheme.surface,
-                        shape = RoundedCornerShape(10.dp),
-                        expanded = groqModelExpanded,
-                        onDismissRequest = { groqModelExpanded = false }
-                    ) {
-                        groqModels.forEach { (id, label) ->
-                            DropdownMenuItem(
-                                text = { Text(label) },
-                                onClick = {
-                                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                    groqModel = id
-                                    prefs.edit().putString(PrefKeys.GROQ_MODEL, id).remove(PrefKeys.STRUCTURED_OUTPUT_DISABLED_AT).apply()
-                                    groqModelExpanded = false
-                                }
-                            )
-                        }
+                    onExpandedChange = { groqModelExpanded = it },
+                    models = groqModelList,
+                    labelFor = { GroqModels.label(it) },
+                    onSelect = { id ->
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        groqModel = id
+                        prefs.edit().putString(PrefKeys.GROQ_MODEL, id).remove(PrefKeys.STRUCTURED_OUTPUT_DISABLED_AT).apply()
+                        groqModelExpanded = false
+                    },
+                    onDismiss = { groqModelExpanded = false },
+                    isFetching = isFetchingGroqModels
+                )
+                ModelFetchStatusRow(
+                    enabled = apiKeys.isNotEmpty(),
+                    isFetching = isFetchingGroqModels,
+                    fetchingText = fetchingModelsMsg,
+                    needKeyText = modelsNeedKeyMsg,
+                    refreshText = modelsRefreshMsg,
+                    message = groqFetchMessage,
+                    success = groqFetchSuccess,
+                    onRefresh = {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        startModelFetch(ProviderType.GROQ)
                     }
-                }
+                )
+
             } else {
                 Text(
                     text = stringResource(R.string.settings_endpoint_title),
@@ -663,6 +738,102 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     Text(stringResource(R.string.backup_import_cancel))
                 }
             }
+        )
+    }
+}
+
+/**
+ * Read-only dropdown listing one provider's dynamically fetched model ids
+ * (issue #148). Opens only when a key exists, no fetch is in flight, and at
+ * least one model was fetched; the menu caps its height and scrolls so long
+ * provider catalogs stay usable.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DynamicModelDropdown(
+    selectedLabel: String,
+    enabled: Boolean,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    models: List<String>,
+    labelFor: (String) -> String,
+    onSelect: (String) -> Unit,
+    onDismiss: () -> Unit,
+    isFetching: Boolean
+) {
+    val openable = enabled && !isFetching && models.isNotEmpty()
+    ExposedDropdownMenuBox(
+        expanded = expanded && openable,
+        onExpandedChange = { if (openable) onExpandedChange(it) }
+    ) {
+        SlateTextField(
+            value = selectedLabel,
+            onValueChange = {},
+            readOnly = true,
+            modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
+        )
+        ExposedDropdownMenu(
+            containerColor = MaterialTheme.colorScheme.surface,
+            shape = RoundedCornerShape(10.dp),
+            expanded = expanded && openable,
+            onDismissRequest = onDismiss,
+            // Provider catalogs can exceed a hundred entries — cap and scroll.
+            modifier = Modifier.heightIn(max = 320.dp)
+        ) {
+            models.forEach { id ->
+                DropdownMenuItem(
+                    text = { Text(labelFor(id)) },
+                    onClick = { onSelect(id) }
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Status + action row under a dynamic model dropdown: a hint when no API key is
+ * registered, a fetching indicator while the list loads, and a Refresh button to
+ * re-pull on demand; any completed-fetch message renders beneath it.
+ */
+@Composable
+private fun ModelFetchStatusRow(
+    enabled: Boolean,
+    isFetching: Boolean,
+    fetchingText: String,
+    needKeyText: String,
+    refreshText: String,
+    message: String?,
+    success: Boolean,
+    onRefresh: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        val statusText = when {
+            !enabled -> needKeyText
+            isFetching -> fetchingText
+            else -> null
+        }
+        if (statusText != null) {
+            Text(
+                text = statusText,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 13.sp,
+                modifier = Modifier.weight(1f)
+            )
+        }
+        TextButton(onClick = onRefresh, enabled = enabled && !isFetching) {
+            Text(refreshText)
+        }
+    }
+    message?.let { msg ->
+        Text(
+            text = msg,
+            color = if (success) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 13.sp,
+            modifier = Modifier.padding(top = 4.dp)
         )
     }
 }

--- a/app/src/main/java/com/musheer360/swiftslate/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/components/CommonComponents.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.sp
 fun SlateCard(
     modifier: Modifier = Modifier,
     fillHeight: Boolean = false,
+    contentPadding: PaddingValues = PaddingValues(13.dp),
     content: @Composable ColumnScope.() -> Unit
 ) {
     Surface(
@@ -24,7 +25,7 @@ fun SlateCard(
     ) {
         Column(
             modifier = Modifier
-                .padding(14.dp)
+                .padding(contentPadding)
                 .then(if (fillHeight) Modifier.fillMaxHeight() else Modifier),
             content = content
         )
@@ -38,7 +39,7 @@ fun ScreenTitle(title: String) {
         fontSize = 32.sp,
         fontWeight = FontWeight.Bold,
         color = MaterialTheme.colorScheme.onBackground,
-        modifier = Modifier.padding(bottom = 20.dp)
+        modifier = Modifier.padding(bottom = 12.dp)
     )
 }
 

--- a/app/src/main/java/com/musheer360/swiftslate/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/components/CommonComponents.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.unit.sp
 fun SlateCard(
     modifier: Modifier = Modifier,
     fillHeight: Boolean = false,
-    contentPadding: PaddingValues = PaddingValues(13.dp),
+    contentPadding: PaddingValues = PaddingValues(12.dp),
     content: @Composable ColumnScope.() -> Unit
 ) {
     Surface(

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -144,6 +144,10 @@
     <string name="settings_fetch_models_success">تم تحميل %1$d نموذجاً</string>
     <string name="settings_fetch_models_empty">لم يتم العثور على نماذج. يمكنك إدخال اسم نموذج يدوياً.</string>
     <string name="settings_fetch_models_failed">تعذّر جلب النماذج. تحقق من عنوان الخادم ومفتاح API.</string>
+    <string name="settings_models_refresh">تحديث</string>
+    <string name="settings_models_need_key">أضِف مفتاح API أعلاه لتحميل قائمة النماذج.</string>
+    <string name="settings_models_load_failed">تعذّر تحميل النماذج. تحقّق من اتصالك ومفتاح API.</string>
+    <string name="settings_models_empty_provider">لا تتوفر نماذج لمفتاح API هذا.</string>
     <string name="dashboard_service_killed_title">تمت مقاطعة SwiftSlate</string>
     <string name="dashboard_service_killed_message">توقفت خدمة الخلفية بشكل غير متوقع. أعد تفعيلها في إعدادات إمكانية الوصول لمواصلة استخدام الأوامر.</string>
     <string name="dashboard_service_killed_dismiss">تجاهل</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -144,6 +144,10 @@
     <string name="settings_fetch_models_success">Заредени са %1$d модела</string>
     <string name="settings_fetch_models_empty">Не са намерени модели. Все пак можете да въведете модел ръчно.</string>
     <string name="settings_fetch_models_failed">Моделите не можаха да бъдат заредени. Проверете адреса и API ключа.</string>
+    <string name="settings_models_refresh">Обнови</string>
+    <string name="settings_models_need_key">Добавете API ключ по-горе, за да заредите списъка с модели.</string>
+    <string name="settings_models_load_failed">Моделите не успяха да се заредят. Проверете връзката и API ключа.</string>
+    <string name="settings_models_empty_provider">Няма налични модели за този API ключ.</string>
     <string name="dashboard_service_killed_title">SwiftSlate беше прекъснат</string>
     <string name="dashboard_service_killed_message">Фоновата услуга спря неочаквано. Активирайте я отново в настройките за достъпност, за да продължите да използвате командите.</string>
     <string name="dashboard_service_killed_dismiss">Отхвърли</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -144,6 +144,10 @@
     <string name="settings_fetch_models_success">S\'han carregat %1$d models</string>
     <string name="settings_fetch_models_empty">No s\'ha trobat cap model. Podeu introduir-ne un manualment.</string>
     <string name="settings_fetch_models_failed">No s\'han pogut obtenir els models. Comproveu l\'adreça i la clau d\'API.</string>
+    <string name="settings_models_refresh">Actualitza</string>
+    <string name="settings_models_need_key">Afegeix una clau d\'API a dalt per carregar la llista de models.</string>
+    <string name="settings_models_load_failed">No s\'han pogut carregar els models. Comproveu la connexió i la clau d\'API.</string>
+    <string name="settings_models_empty_provider">Cap model disponible per a aquesta clau d\'API.</string>
     <string name="dashboard_service_killed_title">S\'ha interromput SwiftSlate</string>
     <string name="dashboard_service_killed_message">El servei en segon pla s\'ha aturat de manera inesperada. Torneu a activar-lo als paràmetres d\'accessibilitat per continuar fent servir les ordres.</string>
     <string name="dashboard_service_killed_dismiss">Ignora</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -144,6 +144,10 @@
     <string name="settings_fetch_models_success">Načteno modelů: %1$d</string>
     <string name="settings_fetch_models_empty">Nebyly nalezeny žádné modely. Model můžete zadat ručně.</string>
     <string name="settings_fetch_models_failed">Modely nelze načíst. Zkontrolujte adresu a klíč API.</string>
+    <string name="settings_models_refresh">Obnovit</string>
+    <string name="settings_models_need_key">Pro načtení seznamu modelů přidejte výše klíč API.</string>
+    <string name="settings_models_load_failed">Modely se nepodařilo načíst. Zkontrolujte připojení a klíč API.</string>
+    <string name="settings_models_empty_provider">Pro tento klíč API nejsou dostupné žádné modely.</string>
     <string name="dashboard_service_killed_title">Aplikace SwiftSlate byla přerušena</string>
     <string name="dashboard_service_killed_message">Služba na pozadí se neočekávaně zastavila. Znovu ji povolte v nastavení usnadnění, abyste mohli dál používat příkazy.</string>
     <string name="dashboard_service_killed_dismiss">Zavřít</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -144,6 +144,10 @@
     <string name="settings_fetch_models_success">%1$d modeller indlæst</string>
     <string name="settings_fetch_models_empty">Ingen modeller fundet. Du kan stadig indtaste en model manuelt.</string>
     <string name="settings_fetch_models_failed">Kunne ikke hente modeller. Tjek adressen og API-nøglen.</string>
+    <string name="settings_models_refresh">Opdater</string>
+    <string name="settings_models_need_key">Tilføj en API-nøgle ovenfor for at indlæse modellisten.</string>
+    <string name="settings_models_load_failed">Kunne ikke indlæse modeller. Tjek din forbindelse og din API-nøgle.</string>
+    <string name="settings_models_empty_provider">Ingen modeller er tilgængelige for denne API-nøgle.</string>
     <string name="dashboard_service_killed_title">SwiftSlate blev afbrudt</string>
     <string name="dashboard_service_killed_message">Baggrundstjenesten stoppede uventet. Aktivér den igen i tilgængelighedsindstillingerne for at fortsætte med at bruge kommandoer.</string>
     <string name="dashboard_service_killed_dismiss">Afvis</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -143,6 +143,10 @@
     <string name="settings_fetch_models_success">%1$d Modelle geladen</string>
     <string name="settings_fetch_models_empty">Keine Modelle gefunden. Du kannst ein Modell trotzdem manuell eingeben.</string>
     <string name="settings_fetch_models_failed">Modelle konnten nicht abgerufen werden. Prüfe die Adresse und den API-Schlüssel.</string>
+    <string name="settings_models_refresh">Aktualisieren</string>
+    <string name="settings_models_need_key">Füge oben einen API-Schlüssel hinzu, um die Modellliste zu laden.</string>
+    <string name="settings_models_load_failed">Modelle konnten nicht geladen werden. Prüfe Verbindung und API-Schlüssel.</string>
+    <string name="settings_models_empty_provider">Für diesen API-Schlüssel sind keine Modelle verfügbar.</string>
     <string name="dashboard_service_killed_title">SwiftSlate wurde unterbrochen</string>
     <string name="dashboard_service_killed_message">Der Hintergrunddienst wurde unerwartet beendet. Aktiviere ihn in den Bedienungshilfen erneut, um Befehle weiter zu verwenden.</string>
     <string name="dashboard_service_killed_dismiss">Schließen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -144,6 +144,10 @@
     <string name="settings_fetch_models_success">Φορτώθηκαν %1$d μοντέλα</string>
     <string name="settings_fetch_models_empty">Δεν βρέθηκαν μοντέλα. Μπορείτε να εισαγάγετε ένα μοντέλο χειροκίνητα.</string>
     <string name="settings_fetch_models_failed">Δεν ήταν δυνατή η λήψη των μοντέλων. Ελέγξτε τη διεύθυνση και το κλειδί API.</string>
+    <string name="settings_models_refresh">Ανανέωση</string>
+    <string name="settings_models_need_key">Προσθέστε ένα κλειδί API παραπάνω για να φορτώσει η λίστα μοντέλων.</string>
+    <string name="settings_models_load_failed">Δεν ήταν δυνατή η φόρτωση των μοντέλων. Ελέγξτε τη σύνδεση και το κλειδί API.</string>
+    <string name="settings_models_empty_provider">Δεν υπάρχουν διαθέσιμα μοντέλα για αυτό το κλειδί API.</string>
     <string name="dashboard_service_killed_title">Το SwiftSlate διακόπηκε</string>
     <string name="dashboard_service_killed_message">Η υπηρεσία παρασκηνίου σταμάτησε απροσδόκητα. Ενεργοποιήστε την ξανά στις ρυθμίσεις προσβασιμότητας για να συνεχίσετε να χρησιμοποιείτε εντολές.</string>
     <string name="dashboard_service_killed_dismiss">Απόρριψη</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -141,6 +141,10 @@
     <string name="settings_fetch_models_success">%1$d modelos cargados</string>
     <string name="settings_fetch_models_empty">No se encontraron modelos. Puedes introducir uno manualmente.</string>
     <string name="settings_fetch_models_failed">No se pudieron obtener los modelos. Revisa la dirección y la clave API.</string>
+    <string name="settings_models_refresh">Actualizar</string>
+    <string name="settings_models_need_key">Añade una clave de API arriba para cargar la lista de modelos.</string>
+    <string name="settings_models_load_failed">No se pudieron cargar los modelos. Comprueba tu conexión y tu clave de API.</string>
+    <string name="settings_models_empty_provider">No hay modelos disponibles para esta clave de API.</string>
     <string name="dashboard_service_killed_title">SwiftSlate se interrumpió</string>
     <string name="dashboard_service_killed_message">El servicio en segundo plano se detuvo inesperadamente. Vuelve a activarlo en los ajustes de accesibilidad para seguir usando comandos.</string>
     <string name="dashboard_service_killed_dismiss">Descartar</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">Laaditud: %1$d mudelit</string>
     <string name="settings_fetch_models_empty">Mudeleid ei leitud. Mudeli saad sisestada ka käsitsi.</string>
     <string name="settings_fetch_models_failed">Mudelite laadimine ebaõnnestus. Kontrolli aadressi ja API-võtit.</string>
+    <string name="settings_models_refresh">Värskenda</string>
+    <string name="settings_models_need_key">Mudelite loendi laadimiseks lisage ülalpool API-võti.</string>
+    <string name="settings_models_load_failed">Mudeleid ei õnnestunud laadida. Kontrollige ühendust ja API-võtit.</string>
+    <string name="settings_models_empty_provider">Selle API-võtme jaoks pole ühtegi mudelit saadaval.</string>
     <string name="dashboard_service_killed_title">SwiftSlate katkes</string>
     <string name="dashboard_service_killed_message">Taustateenus peatus ootamatult. Lülita see juurdepääsetavuse seadetes uuesti sisse, et käske edasi kasutada.</string>
     <string name="dashboard_service_killed_dismiss">Loobu</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">%1$d مدل بارگیری شد</string>
     <string name="settings_fetch_models_empty">مدلی پیدا نشد. همچنان میتوانید نام مدل را دستی وارد کنید.</string>
     <string name="settings_fetch_models_failed">دریافت مدلها ممکن نشد. آدرس و کلید API را بررسی کنید.</string>
+    <string name="settings_models_refresh">بازآوری</string>
+    <string name="settings_models_need_key">برای بارگذاری فهرست مدل‌ها، یک کلید API در بالا اضافه کنید.</string>
+    <string name="settings_models_load_failed">بارگذاری مدل‌ها ممکن نشد. اتصال و کلید API خود را بررسی کنید.</string>
+    <string name="settings_models_empty_provider">برای این کلید API هیچ مدلی در دسترس نیست.</string>
     <string name="dashboard_service_killed_title">SwiftSlate متوقف شد</string>
     <string name="dashboard_service_killed_message">سرویس پس‌زمینه به‌طور غیرمنتظره متوقف شد. برای ادامه استفاده از دستورها، آن را در تنظیمات دسترس‌پذیری دوباره فعال کنید.</string>
     <string name="dashboard_service_killed_dismiss">رد کردن</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">%1$d mallia ladattu</string>
     <string name="settings_fetch_models_empty">Malleja ei löytynyt. Voit silti syöttää mallin käsin.</string>
     <string name="settings_fetch_models_failed">Malleja ei voitu hakea. Tarkista osoite ja API-avain.</string>
+    <string name="settings_models_refresh">Päivitä</string>
+    <string name="settings_models_need_key">Lisää yläpuolelle API-avain ladataksesi mallilistan.</string>
+    <string name="settings_models_load_failed">Malleja ei voitu ladata. Tarkista yhteys ja API-avain.</string>
+    <string name="settings_models_empty_provider">Tälle API-avaimelle ei ole saatavilla malleja.</string>
     <string name="dashboard_service_killed_title">SwiftSlate keskeytyi</string>
     <string name="dashboard_service_killed_message">Taustapalvelu pysähtyi odottamatta. Ota se uudelleen käyttöön esteettömyysasetuksista, jotta voit jatkaa komentojen käyttöä.</string>
     <string name="dashboard_service_killed_dismiss">Sulje</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -141,6 +141,10 @@
     <string name="settings_fetch_models_success">%1$d modèles chargés</string>
     <string name="settings_fetch_models_empty">Aucun modèle trouvé. Vous pouvez quand même saisir un modèle manuellement.</string>
     <string name="settings_fetch_models_failed">Impossible de récupérer les modèles. Vérifiez l\'adresse et la clé API.</string>
+    <string name="settings_models_refresh">Actualiser</string>
+    <string name="settings_models_need_key">Ajoute une clé API ci-dessus pour charger la liste des modèles.</string>
+    <string name="settings_models_load_failed">Impossible de charger les modèles. Vérifie ta connexion et ta clé API.</string>
+    <string name="settings_models_empty_provider">Aucun modèle disponible pour cette clé API.</string>
     <string name="dashboard_service_killed_title">SwiftSlate a été interrompu</string>
     <string name="dashboard_service_killed_message">Le service en arrière-plan s\'est arrêté de manière inattendue. Réactivez-le dans les paramètres d\'accessibilité pour continuer à utiliser les commandes.</string>
     <string name="dashboard_service_killed_dismiss">Ignorer</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -141,6 +141,10 @@
     <string name="settings_fetch_models_success">%1$d मॉडल लोड हुए</string>
     <string name="settings_fetch_models_empty">कोई मॉडल नहीं मिला। आप फिर भी मैन्युअल रूप से मॉडल दर्ज कर सकते हैं।</string>
     <string name="settings_fetch_models_failed">मॉडल नहीं लाए जा सके। एंडपॉइंट और API कुंजी जाँचें।</string>
+    <string name="settings_models_refresh">रिफ्रेश</string>
+    <string name="settings_models_need_key">मॉडल सूची लोड करने के लिए ऊपर कोई API कुंजी जोड़ें।</string>
+    <string name="settings_models_load_failed">मॉडल लोड नहीं हो सके। अपना कनेक्शन और API कुंजी जाँचें।</string>
+    <string name="settings_models_empty_provider">इस API कुंजी के लिए कोई मॉडल उपलब्ध नहीं है।</string>
     <string name="dashboard_service_killed_title">SwiftSlate बाधित हो गया</string>
     <string name="dashboard_service_killed_message">बैकग्राउंड सेवा अप्रत्याशित रूप से बंद हो गई। कमांड का उपयोग जारी रखने के लिए इसे सुलभता सेटिंग में फिर से सक्षम करें।</string>
     <string name="dashboard_service_killed_dismiss">खारिज करें</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">Učitano modela: %1$d</string>
     <string name="settings_fetch_models_empty">Nema pronađenih modela. Ipak možete ručno unijeti model.</string>
     <string name="settings_fetch_models_failed">Modele nije moguće dohvatiti. Provjerite adresu i API ključ.</string>
+    <string name="settings_models_refresh">Osvježi</string>
+    <string name="settings_models_need_key">Za učitavanje popisa modela dodaj iznad API ključ.</string>
+    <string name="settings_models_load_failed">Učitavanje modela nije uspjelo. Provjeri vezu i API ključ.</string>
+    <string name="settings_models_empty_provider">Za ovaj API ključ nema dostupnih modela.</string>
     <string name="dashboard_service_killed_title">SwiftSlate je prekinut</string>
     <string name="dashboard_service_killed_message">Pozadinska usluga neočekivano se zaustavila. Ponovno je omogućite u postavkama pristupačnosti kako biste nastavili koristiti naredbe.</string>
     <string name="dashboard_service_killed_dismiss">Zatvori</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">%1$d modell betöltve</string>
     <string name="settings_fetch_models_empty">Nem találhatók modellek. Kézzel is megadhat egy modellt.</string>
     <string name="settings_fetch_models_failed">Nem sikerült lekérni a modelleket. Ellenőrizze a címet és az API-kulcsot.</string>
+    <string name="settings_models_refresh">Frissítés</string>
+    <string name="settings_models_need_key">Adj meg fentebb egy API-kulcsot a modelllista betöltéséhez.</string>
+    <string name="settings_models_load_failed">A modelleket nem sikerült betölteni. Ellenőrizd a kapcsolatot és az API-kulcsot.</string>
+    <string name="settings_models_empty_provider">Ehhez az API-kulcshoz nincsenek elérhető modellek.</string>
     <string name="dashboard_service_killed_title">A SwiftSlate megszakadt</string>
     <string name="dashboard_service_killed_message">A háttérszolgáltatás váratlanul leállt. Engedélyezze újra a kisegítő lehetőségek beállításaiban a parancsok további használatához.</string>
     <string name="dashboard_service_killed_dismiss">Elvetés</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">%1$d model dimuat</string>
     <string name="settings_fetch_models_empty">Tidak ada model ditemukan. Anda tetap bisa memasukkan model secara manual.</string>
     <string name="settings_fetch_models_failed">Gagal mengambil model. Periksa alamat dan kunci API.</string>
+    <string name="settings_models_refresh">Muat ulang</string>
+    <string name="settings_models_need_key">Tambahkan kunci API di atas untuk memuat daftar model.</string>
+    <string name="settings_models_load_failed">Tidak dapat memuat model. Periksa koneksi dan kunci API Anda.</string>
+    <string name="settings_models_empty_provider">Tidak ada model yang tersedia untuk kunci API ini.</string>
     <string name="dashboard_service_killed_title">SwiftSlate terhenti</string>
     <string name="dashboard_service_killed_message">Layanan latar belakang berhenti secara tak terduga. Aktifkan lagi di setelan aksesibilitas untuk terus menggunakan perintah.</string>
     <string name="dashboard_service_killed_dismiss">Abaikan</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">Caricati %1$d modelli</string>
     <string name="settings_fetch_models_empty">Nessun modello trovato. Puoi comunque inserirne uno manualmente.</string>
     <string name="settings_fetch_models_failed">Impossibile recuperare i modelli. Controlla l\'indirizzo e la chiave API.</string>
+    <string name="settings_models_refresh">Aggiorna</string>
+    <string name="settings_models_need_key">Aggiungi una chiave API qui sopra per caricare l\'elenco dei modelli.</string>
+    <string name="settings_models_load_failed">Impossibile caricare i modelli. Controlla la connessione e la chiave API.</string>
+    <string name="settings_models_empty_provider">Nessun modello disponibile per questa chiave API.</string>
     <string name="dashboard_service_killed_title">SwiftSlate è stato interrotto</string>
     <string name="dashboard_service_killed_message">Il servizio in background si è arrestato in modo imprevisto. Riattivalo nelle impostazioni di accessibilità per continuare a usare i comandi.</string>
     <string name="dashboard_service_killed_dismiss">Ignora</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">נטענו %1$d מודלים</string>
     <string name="settings_fetch_models_empty">לא נמצאו מודלים. עדיין ניתן להזין מודל ידנית.</string>
     <string name="settings_fetch_models_failed">לא ניתן לאחזר את המודלים. בדקו את הכתובת ואת מפתח ה-API.</string>
+    <string name="settings_models_refresh">רענון</string>
+    <string name="settings_models_need_key">הוסיפו מפתח API למעלה כדי לטעון את רשימת המודלים.</string>
+    <string name="settings_models_load_failed">טעינת המודלים נכשלה. בדקו את החיבור ואת מפתח ה-API.</string>
+    <string name="settings_models_empty_provider">אין מודלים זמינים למפתח ה-API הזה.</string>
     <string name="dashboard_service_killed_title">SwiftSlate הופסק</string>
     <string name="dashboard_service_killed_message">שירות הרקע נעצר באופן בלתי צפוי. הפעילו אותו שוב בהגדרות הנגישות כדי להמשיך להשתמש בפקודות.</string>
     <string name="dashboard_service_killed_dismiss">ביטול</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">%1$d 件のモデルを読み込みました</string>
     <string name="settings_fetch_models_empty">モデルが見つかりません。手動でモデルを入力することもできます。</string>
     <string name="settings_fetch_models_failed">モデルを取得できませんでした。アドレスと API キーを確認してください。</string>
+    <string name="settings_models_refresh">更新</string>
+    <string name="settings_models_need_key">モデルリストを読み込むには上でAPIキーを追加してください。</string>
+    <string name="settings_models_load_failed">モデルを読み込めませんでした。接続とAPIキーを確認してください。</string>
+    <string name="settings_models_empty_provider">このAPIキーで利用可能なモデルはありません。</string>
     <string name="dashboard_service_killed_title">SwiftSlate が中断されました</string>
     <string name="dashboard_service_killed_message">バックグラウンド サービスが予期せず停止しました。コマンドを使い続けるには、アクセシビリティ設定で再度有効にしてください。</string>
     <string name="dashboard_service_killed_dismiss">閉じる</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">%1$d개 모델 로드됨</string>
     <string name="settings_fetch_models_empty">모델을 찾지 못했습니다. 모델을 수동으로 입력할 수 있습니다.</string>
     <string name="settings_fetch_models_failed">모델을 가져오지 못했습니다. 주소와 API 키를 확인하세요.</string>
+    <string name="settings_models_refresh">새로고침</string>
+    <string name="settings_models_need_key">모델 목록을 불러오려면 위에서 API 키를 추가하세요.</string>
+    <string name="settings_models_load_failed">모델을 불러오지 못했습니다. 연결과 API 키를 확인하세요.</string>
+    <string name="settings_models_empty_provider">이 API 키에 사용할 수 있는 모델이 없습니다.</string>
     <string name="dashboard_service_killed_title">SwiftSlate이(가) 중단되었습니다</string>
     <string name="dashboard_service_killed_message">백그라운드 서비스가 예기치 않게 중지되었습니다. 명령을 계속 사용하려면 접근성 설정에서 다시 활성화하세요.</string>
     <string name="dashboard_service_killed_dismiss">닫기</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">Įkelta modelių: %1$d</string>
     <string name="settings_fetch_models_empty">Modelių nerasta. Modelį vis tiek galite įvesti rankiniu būdu.</string>
     <string name="settings_fetch_models_failed">Nepavyko gauti modelių. Patikrinkite adresą ir API raktą.</string>
+    <string name="settings_models_refresh">Atnaujinti</string>
+    <string name="settings_models_need_key">Norėdami įkelti modelių sąrašą, aukščiau pridėkite API raktą.</string>
+    <string name="settings_models_load_failed">Nepavyko įkelti modelių. Patikrinkite ryšį ir API raktą.</string>
+    <string name="settings_models_empty_provider">Šiam API raktui nėra galimų modelių.</string>
     <string name="dashboard_service_killed_title">SwiftSlate buvo nutraukta</string>
     <string name="dashboard_service_killed_message">Foninė tarnyba netikėtai sustojo. Iš naujo įjunkite ją pritaikymo neįgaliesiems nustatymuose, kad galėtumėte toliau naudoti komandas.</string>
     <string name="dashboard_service_killed_dismiss">Uždaryti</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">Ielādēti %1$d modeļi</string>
     <string name="settings_fetch_models_empty">Nav atrasts neviens modelis. Modeli varat ievadīt manuāli.</string>
     <string name="settings_fetch_models_failed">Neizdevās iegūt modeļus. Pārbaudiet adresi un API atslēgu.</string>
+    <string name="settings_models_refresh">Atjaunināt</string>
+    <string name="settings_models_need_key">Lai ielādētu modeļu sarakstu, augstāk pievienojiet API atslēgu.</string>
+    <string name="settings_models_load_failed">Nevarēja ielādēt modeļus. Pārbaudiet savienojumu un API atslēgu.</string>
+    <string name="settings_models_empty_provider">Šai API atslēgai nav pieejamu modeļu.</string>
     <string name="dashboard_service_killed_title">SwiftSlate tika pārtraukts</string>
     <string name="dashboard_service_killed_message">Fona pakalpojums negaidīti apstājās. Atkārtoti iespējojiet to pieejamības iestatījumos, lai turpinātu lietot komandas.</string>
     <string name="dashboard_service_killed_dismiss">Aizvērt</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">%1$d model dimuatkan</string>
     <string name="settings_fetch_models_empty">Tiada model ditemui. Anda masih boleh memasukkan model secara manual.</string>
     <string name="settings_fetch_models_failed">Model tidak dapat diperoleh. Semak alamat dan kunci API.</string>
+    <string name="settings_models_refresh">Muat semula</string>
+    <string name="settings_models_need_key">Tambahkan kunci API di atas untuk memuatkan senarai model.</string>
+    <string name="settings_models_load_failed">Tidak dapat memuatkan model. Semak sambungan dan kunci API anda.</string>
+    <string name="settings_models_empty_provider">Tiada model tersedia untuk kunci API ini.</string>
     <string name="dashboard_service_killed_title">SwiftSlate terganggu</string>
     <string name="dashboard_service_killed_message">Perkhidmatan latar belakang berhenti tanpa diduga. Dayakan semula dalam tetapan kebolehaksesan untuk terus menggunakan arahan.</string>
     <string name="dashboard_service_killed_dismiss">Abaikan</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">%1$d modeller lastet</string>
     <string name="settings_fetch_models_empty">Ingen modeller funnet. Du kan fortsatt skrive inn en modell manuelt.</string>
     <string name="settings_fetch_models_failed">Kunne ikke hente modeller. Sjekk adressen og API-nøkkelen.</string>
+    <string name="settings_models_refresh">Oppdater</string>
+    <string name="settings_models_need_key">Legg til en API-nøkkel over for å laste inn modellisten.</string>
+    <string name="settings_models_load_failed">Kunne ikke laste inn modeller. Sjekk tilkoblingen og API-nøkkelen.</string>
+    <string name="settings_models_empty_provider">Ingen modeller er tilgjengelige for denne API-nøkkelen.</string>
     <string name="dashboard_service_killed_title">SwiftSlate ble avbrutt</string>
     <string name="dashboard_service_killed_message">Bakgrunnstjenesten stoppet uventet. Slå den på igjen i tilgjengelighetsinnstillingene for å fortsette å bruke kommandoer.</string>
     <string name="dashboard_service_killed_dismiss">Lukk</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">%1$d modellen geladen</string>
     <string name="settings_fetch_models_empty">Geen modellen gevonden. Je kunt nog steeds handmatig een model invoeren.</string>
     <string name="settings_fetch_models_failed">Modellen konden niet worden opgehaald. Controleer het adres en de API-sleutel.</string>
+    <string name="settings_models_refresh">Vernieuwen</string>
+    <string name="settings_models_need_key">Voeg hierboven een API-sleutel toe om de modellenlijst te laden.</string>
+    <string name="settings_models_load_failed">Kon modellen niet laden. Controleer je verbinding en API-sleutel.</string>
+    <string name="settings_models_empty_provider">Geen modellen beschikbaar voor deze API-sleutel.</string>
     <string name="dashboard_service_killed_title">SwiftSlate is onderbroken</string>
     <string name="dashboard_service_killed_message">De achtergrondservice is onverwacht gestopt. Schakel deze opnieuw in bij de toegankelijkheidsinstellingen om opdrachten te blijven gebruiken.</string>
     <string name="dashboard_service_killed_dismiss">Sluiten</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">Wczytano modeli: %1$d</string>
     <string name="settings_fetch_models_empty">Nie znaleziono modeli. Nadal możesz wpisać model ręcznie.</string>
     <string name="settings_fetch_models_failed">Nie udało się pobrać modeli. Sprawdź adres i klucz API.</string>
+    <string name="settings_models_refresh">Odśwież</string>
+    <string name="settings_models_need_key">Dodaj powyżej klucz API, aby wczytać listę modeli.</string>
+    <string name="settings_models_load_failed">Nie udało się wczytać modeli. Sprawdź połączenie i klucz API.</string>
+    <string name="settings_models_empty_provider">Brak dostępnych modeli dla tego klucza API.</string>
     <string name="dashboard_service_killed_title">Aplikacja SwiftSlate została przerwana</string>
     <string name="dashboard_service_killed_message">Usługa działająca w tle nieoczekiwanie się zatrzymała. Włącz ją ponownie w ustawieniach ułatwień dostępu, aby nadal używać poleceń.</string>
     <string name="dashboard_service_killed_dismiss">Zamknij</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -141,6 +141,10 @@
     <string name="settings_fetch_models_success">%1$d modelos carregados</string>
     <string name="settings_fetch_models_empty">Nenhum modelo encontrado. Você ainda pode inserir um modelo manualmente.</string>
     <string name="settings_fetch_models_failed">Não foi possível obter os modelos. Verifique o endereço e a chave da API.</string>
+    <string name="settings_models_refresh">Atualizar</string>
+    <string name="settings_models_need_key">Adicione uma chave de API acima para carregar a lista de modelos.</string>
+    <string name="settings_models_load_failed">Não foi possível carregar os modelos. Verifique sua conexão e sua chave de API.</string>
+    <string name="settings_models_empty_provider">Nenhum modelo disponível para esta chave de API.</string>
     <string name="dashboard_service_killed_title">O SwiftSlate foi interrompido</string>
     <string name="dashboard_service_killed_message">O serviço em segundo plano parou inesperadamente. Reative-o nas configurações de acessibilidade para continuar usando comandos.</string>
     <string name="dashboard_service_killed_dismiss">Dispensar</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">%1$d modelos carregados</string>
     <string name="settings_fetch_models_empty">Nenhum modelo encontrado. Ainda pode introduzir um modelo manualmente.</string>
     <string name="settings_fetch_models_failed">Não foi possível obter os modelos. Verifique o endereço e a chave da API.</string>
+    <string name="settings_models_refresh">Atualizar</string>
+    <string name="settings_models_need_key">Adiciona uma chave de API acima para carregar a lista de modelos.</string>
+    <string name="settings_models_load_failed">Não foi possível carregar os modelos. Verifica a tua ligação e a tua chave de API.</string>
+    <string name="settings_models_empty_provider">Nenhum modelo disponível para esta chave de API.</string>
     <string name="dashboard_service_killed_title">O SwiftSlate foi interrompido</string>
     <string name="dashboard_service_killed_message">O serviço em segundo plano parou inesperadamente. Volte a ativá-lo nas definições de acessibilidade para continuar a usar comandos.</string>
     <string name="dashboard_service_killed_dismiss">Dispensar</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">S-au încărcat %1$d modele</string>
     <string name="settings_fetch_models_empty">Nu s-au găsit modele. Puteți introduce totuși un model manual.</string>
     <string name="settings_fetch_models_failed">Nu s-au putut obține modelele. Verificați adresa și cheia API.</string>
+    <string name="settings_models_refresh">Reîmprospătează</string>
+    <string name="settings_models_need_key">Adaugă mai sus o cheie API pentru a încărca lista de modele.</string>
+    <string name="settings_models_load_failed">Nu s-au putut încărca modelele. Verifică conexiunea și cheia API.</string>
+    <string name="settings_models_empty_provider">Nu există modele disponibile pentru această cheie API.</string>
     <string name="dashboard_service_killed_title">SwiftSlate a fost întrerupt</string>
     <string name="dashboard_service_killed_message">Serviciul din fundal s-a oprit în mod neașteptat. Reactivați-l în setările de accesibilitate pentru a continua să folosiți comenzile.</string>
     <string name="dashboard_service_killed_dismiss">Închide</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">Загружено моделей: %1$d</string>
     <string name="settings_fetch_models_empty">Модели не найдены. Вы всё равно можете ввести модель вручную.</string>
     <string name="settings_fetch_models_failed">Не удалось загрузить модели. Проверьте адрес и ключ API.</string>
+    <string name="settings_models_refresh">Обновить</string>
+    <string name="settings_models_need_key">Добавьте выше API-ключ, чтобы загрузить список моделей.</string>
+    <string name="settings_models_load_failed">Не удалось загрузить модели. Проверьте соединение и API-ключ.</string>
+    <string name="settings_models_empty_provider">Для этого API-ключа нет доступных моделей.</string>
     <string name="dashboard_service_killed_title">SwiftSlate был прерван</string>
     <string name="dashboard_service_killed_message">Фоновая служба неожиданно остановилась. Снова включите её в настройках специальных возможностей, чтобы продолжить использовать команды.</string>
     <string name="dashboard_service_killed_dismiss">Скрыть</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">Načítaných modelov: %1$d</string>
     <string name="settings_fetch_models_empty">Nenašli sa žiadne modely. Model môžete zadať ručne.</string>
     <string name="settings_fetch_models_failed">Modely sa nepodarilo načítať. Skontrolujte adresu a kľúč API.</string>
+    <string name="settings_models_refresh">Obnoviť</string>
+    <string name="settings_models_need_key">Pre načítanie zoznamu modelov pridajte vyššie kľúč API.</string>
+    <string name="settings_models_load_failed">Modely sa nepodarilo načítať. Skontrolujte pripojenie a kľúč API.</string>
+    <string name="settings_models_empty_provider">Pre tento kľúč API nie sú dostupné žiadne modely.</string>
     <string name="dashboard_service_killed_title">SwiftSlate bol prerušený</string>
     <string name="dashboard_service_killed_message">Služba na pozadí sa nečakane zastavila. Znova ju povoľte v nastaveniach dostupnosti, aby ste mohli naďalej používať príkazy.</string>
     <string name="dashboard_service_killed_dismiss">Zavrieť</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">Naloženih modelov: %1$d</string>
     <string name="settings_fetch_models_empty">Ni najdenih modelov. Model lahko vseeno vnesete ročno.</string>
     <string name="settings_fetch_models_failed">Modelov ni bilo mogoče pridobiti. Preverite naslov in ključ API.</string>
+    <string name="settings_models_refresh">Osveži</string>
+    <string name="settings_models_need_key">Za nalaganje seznama modelov dodaj zgoraj ključ API.</string>
+    <string name="settings_models_load_failed">Modelov ni bilo mogoče naložiti. Preveri povezavo in ključ API.</string>
+    <string name="settings_models_empty_provider">Za ta ključ API ni na voljo noben model.</string>
     <string name="dashboard_service_killed_title">SwiftSlate je bil prekinjen</string>
     <string name="dashboard_service_killed_message">Storitev v ozadju se je nepričakovano ustavila. Znova jo omogočite v nastavitvah dostopnosti, da boste lahko še naprej uporabljali ukaze.</string>
     <string name="dashboard_service_killed_dismiss">Zapri</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">Учитано модела: %1$d</string>
     <string name="settings_fetch_models_empty">Нису пронађени модели. Ипак можете ручно унети модел.</string>
     <string name="settings_fetch_models_failed">Није било могуће преузети моделе. Проверите адресу и API кључ.</string>
+    <string name="settings_models_refresh">Освежи</string>
+    <string name="settings_models_need_key">Додајте API кључ изнад да бисте учитали листу модела.</string>
+    <string name="settings_models_load_failed">Учитавање модела није успело. Проверите везу и API кључ.</string>
+    <string name="settings_models_empty_provider">Нема доступних модела за овај API кључ.</string>
     <string name="dashboard_service_killed_title">SwiftSlate је прекинут</string>
     <string name="dashboard_service_killed_message">Позадинска услуга се неочекивано зауставила. Поново је омогућите у подешавањима приступачности да бисте наставили да користите команде.</string>
     <string name="dashboard_service_killed_dismiss">Одбаци</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -146,6 +146,10 @@
     <string name="settings_fetch_models_success">%1$d modeller inlästa</string>
     <string name="settings_fetch_models_empty">Inga modeller hittades. Du kan fortfarande ange en modell manuellt.</string>
     <string name="settings_fetch_models_failed">Det gick inte att hämta modeller. Kontrollera slutpunkten och API-nyckeln.</string>
+    <string name="settings_models_refresh">Uppdatera</string>
+    <string name="settings_models_need_key">Lägg till en API-nyckel ovan för att läsa in modellistan.</string>
+    <string name="settings_models_load_failed">Det gick inte att läsa in modeller. Kontrollera anslutningen och API-nyckeln.</string>
+    <string name="settings_models_empty_provider">Inga modeller är tillgängliga för den här API-nyckeln.</string>
     <string name="dashboard_service_killed_title">SwiftSlate avbröts</string>
     <string name="dashboard_service_killed_message">Bakgrundstjänsten stoppades oväntat. Aktivera den igen i tillgänglighetsinställningarna för att fortsätta använda kommandon.</string>
     <string name="dashboard_service_killed_dismiss">Avfärda</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">โหลดแล้ว %1$d โมเดล</string>
     <string name="settings_fetch_models_empty">ไม่พบโมเดล คุณยังป้อนชื่อโมเดลด้วยตนเองได้</string>
     <string name="settings_fetch_models_failed">ไม่สามารถดึงรายชื่อโมเดลได้ ตรวจสอบที่อยู่และคีย์ API</string>
+    <string name="settings_models_refresh">รีเฟรช</string>
+    <string name="settings_models_need_key">เพิ่มคีย์ API ด้านบนเพื่อโหลดรายการโมเดล</string>
+    <string name="settings_models_load_failed">โหลดโมเดลไม่สำเร็จ ตรวจสอบการเชื่อมต่อและคีย์ API ของคุณ</string>
+    <string name="settings_models_empty_provider">ไม่มีโมเดลที่ใช้ได้กับคีย์ API นี้</string>
     <string name="dashboard_service_killed_title">SwiftSlate ถูกขัดจังหวะ</string>
     <string name="dashboard_service_killed_message">บริการพื้นหลังหยุดทำงานโดยไม่คาดคิด เปิดใช้งานอีกครั้งในการตั้งค่าการเข้าถึงเพื่อใช้คำสั่งต่อไป</string>
     <string name="dashboard_service_killed_dismiss">ปิด</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">%1$d model yüklendi</string>
     <string name="settings_fetch_models_empty">Model bulunamadı. Yine de manuel olarak model girebilirsiniz.</string>
     <string name="settings_fetch_models_failed">Modeller getirilemedi. Adresi ve API anahtarını kontrol edin.</string>
+    <string name="settings_models_refresh">Yenile</string>
+    <string name="settings_models_need_key">Model listesini yüklemek için yukarıya bir API anahtarı ekleyin.</string>
+    <string name="settings_models_load_failed">Modeller yüklenemedi. Bağlantınızı ve API anahtarınızı kontrol edin.</string>
+    <string name="settings_models_empty_provider">Bu API anahtarı için kullanılabilir model yok.</string>
     <string name="dashboard_service_killed_title">SwiftSlate kesintiye uğradı</string>
     <string name="dashboard_service_killed_message">Arka plan hizmeti beklenmedik şekilde durdu. Komutları kullanmaya devam etmek için erişilebilirlik ayarlarından yeniden etkinleştirin.</string>
     <string name="dashboard_service_killed_dismiss">Kapat</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">Завантажено моделей: %1$d</string>
     <string name="settings_fetch_models_empty">Моделі не знайдено. Ви все одно можете ввести модель вручну.</string>
     <string name="settings_fetch_models_failed">Не вдалося отримати моделі. Перевірте адресу та ключ API.</string>
+    <string name="settings_models_refresh">Оновити</string>
+    <string name="settings_models_need_key">Додайте вище API-ключ, щоб завантажити список моделей.</string>
+    <string name="settings_models_load_failed">Не вдалося завантажити моделі. Перевірте з\'єднання та API-ключ.</string>
+    <string name="settings_models_empty_provider">Для цього API-ключа немає доступних моделей.</string>
     <string name="dashboard_service_killed_title">SwiftSlate було перервано</string>
     <string name="dashboard_service_killed_message">Фонова служба неочікувано зупинилася. Увімкніть її знову в налаштуваннях доступності, щоб продовжувати використовувати команди.</string>
     <string name="dashboard_service_killed_dismiss">Закрити</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">Đã tải %1$d mô hình</string>
     <string name="settings_fetch_models_empty">Không tìm thấy mô hình nào. Bạn vẫn có thể nhập tên mô hình theo cách thủ công.</string>
     <string name="settings_fetch_models_failed">Không thể lấy danh sách mô hình. Kiểm tra địa chỉ và khóa API.</string>
+    <string name="settings_models_refresh">Làm mới</string>
+    <string name="settings_models_need_key">Thêm khóa API ở phía trên để tải danh sách mô hình.</string>
+    <string name="settings_models_load_failed">Không thể tải mô hình. Kiểm tra kết nối và khóa API của bạn.</string>
+    <string name="settings_models_empty_provider">Không có mô hình nào khả dụng cho khóa API này.</string>
     <string name="dashboard_service_killed_title">SwiftSlate đã bị gián đoạn</string>
     <string name="dashboard_service_killed_message">Dịch vụ nền đã dừng bất ngờ. Hãy bật lại trong cài đặt trợ năng để tiếp tục sử dụng lệnh.</string>
     <string name="dashboard_service_killed_dismiss">Bỏ qua</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -141,6 +141,10 @@
     <string name="settings_fetch_models_success">已加载 %1$d 个模型</string>
     <string name="settings_fetch_models_empty">未找到模型。你仍然可以手动输入模型名称。</string>
     <string name="settings_fetch_models_failed">无法获取模型列表。请检查地址和 API 密钥。</string>
+    <string name="settings_models_refresh">刷新</string>
+    <string name="settings_models_need_key">在上方添加 API 密钥以加载模型列表。</string>
+    <string name="settings_models_load_failed">无法加载模型。请检查网络连接和 API 密钥。</string>
+    <string name="settings_models_empty_provider">此 API 密钥没有可用模型。</string>
     <string name="dashboard_service_killed_title">SwiftSlate 已中断</string>
     <string name="dashboard_service_killed_message">后台服务意外停止。请在无障碍设置中重新启用它，以继续使用命令。</string>
     <string name="dashboard_service_killed_dismiss">忽略</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -142,6 +142,10 @@
     <string name="settings_fetch_models_success">已加载 %1$d 个模型</string>
     <string name="settings_fetch_models_empty">未找到模型。你仍然可以手动输入模型名称。</string>
     <string name="settings_fetch_models_failed">无法获取模型列表。请检查地址和 API 密钥。</string>
+    <string name="settings_models_refresh">重新整理</string>
+    <string name="settings_models_need_key">在上方新增 API 金鑰以載入模型清單。</string>
+    <string name="settings_models_load_failed">無法載入模型。請檢查你的連線與 API 金鑰。</string>
+    <string name="settings_models_empty_provider">此 API 金鑰沒有可用的模型。</string>
     <string name="dashboard_service_killed_title">SwiftSlate 已中断</string>
     <string name="dashboard_service_killed_message">后台服务意外停止。请在无障碍设置中重新启用它，以继续使用命令。</string>
     <string name="dashboard_service_killed_dismiss">忽略</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,8 +148,6 @@
     <string name="settings_fetch_models_success">%1$d models loaded</string>
     <string name="settings_fetch_models_empty">No models found. You can still enter a model manually.</string>
     <string name="settings_fetch_models_failed">Could not fetch models. Check your endpoint and API key.</string>
-    <!-- TODO translate: new strings for the dynamic Gemini/Groq model dropdowns; they fall
-         back to English in the other locales until translated. -->
     <string name="settings_models_refresh">Refresh</string>
     <string name="settings_models_need_key">Add an API key above to load the model list.</string>
     <string name="settings_models_load_failed">Couldn\'t load models. Check your connection and API key.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,6 +148,12 @@
     <string name="settings_fetch_models_success">%1$d models loaded</string>
     <string name="settings_fetch_models_empty">No models found. You can still enter a model manually.</string>
     <string name="settings_fetch_models_failed">Could not fetch models. Check your endpoint and API key.</string>
+    <!-- TODO translate: new strings for the dynamic Gemini/Groq model dropdowns; they fall
+         back to English in the other locales until translated. -->
+    <string name="settings_models_refresh">Refresh</string>
+    <string name="settings_models_need_key">Add an API key above to load the model list.</string>
+    <string name="settings_models_load_failed">Couldn\'t load models. Check your connection and API key.</string>
+    <string name="settings_models_empty_provider">No models are available for this API key.</string>
     <string name="dashboard_service_killed_title">SwiftSlate was interrupted</string>
     <string name="dashboard_service_killed_message">The background service stopped unexpectedly. Re-enable it in accessibility settings to keep using commands.</string>
     <string name="dashboard_service_killed_dismiss">Dismiss</string>

--- a/app/src/test/java/com/musheer360/swiftslate/api/GeminiModelsListParserTest.kt
+++ b/app/src/test/java/com/musheer360/swiftslate/api/GeminiModelsListParserTest.kt
@@ -1,0 +1,67 @@
+package com.musheer360.swiftslate.api
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Runs under Robolectric because [GeminiClient.parseModelsJson] uses org.json,
+ * which is an unimplemented stub in the plain JVM unit-test classpath.
+ */
+@RunWith(RobolectricTestRunner::class)
+class GeminiModelsListParserTest {
+
+    @Test
+    fun keeps_generateContent_models_and_strips_models_prefix() {
+        val json = """
+            {"models":[
+              {"name":"models/gemini-3.6-flash","supportedGenerationMethods":["generateContent"]},
+              {"name":"models/text-embedding-004","supportedGenerationMethods":["embedContent"]},
+              {"name":"models/imagen-4","supportedGenerationMethods":["predict"]}
+            ]}
+        """.trimIndent()
+        assertEquals(listOf("gemini-3.6-flash"), GeminiClient.parseModelsJson(json))
+    }
+
+    @Test
+    fun honors_supportedActions_field_variant() {
+        val json = """
+            {"models":[
+              {"name":"models/gemini-next","supportedActions":["generateContent"]},
+              {"name":"models/aqa-model","supportedActions":["questionAnswering"]}
+            ]}
+        """.trimIndent()
+        assertEquals(listOf("gemini-next"), GeminiClient.parseModelsJson(json))
+    }
+
+    @Test
+    fun fails_open_when_neither_capability_array_present() {
+        val json = """{"models":[{"name":"models/mystery-model"},{"name":"models/gemini-x"}]}"""
+        assertEquals(listOf("mystery-model", "gemini-x"), GeminiClient.parseModelsJson(json))
+    }
+
+    @Test
+    fun dedupes_in_first_seen_order_and_skips_blank_names() {
+        val json = """
+            {"models":[
+              {"name":"models/gemini-a","supportedGenerationMethods":["generateContent"]},
+              {"name":"models/gemini-a","supportedGenerationMethods":["generateContent"]},
+              {"name":"","supportedGenerationMethods":["generateContent"]},
+              {"name":"models/nested/models/gemini-b","supportedGenerationMethods":["generateContent"]}
+            ]}
+        """.trimIndent()
+        // Only ONE leading "models/" is stripped — real ids never nest the prefix,
+        // and repeated stripping could corrupt an id that legitimately contains it.
+        assertEquals(listOf("gemini-a", "nested/models/gemini-b"), GeminiClient.parseModelsJson(json))
+    }
+
+    @Test
+    fun non_json_or_empty_bodies_yield_empty_list() {
+        assertEquals(emptyList<String>(), GeminiClient.parseModelsJson(""))
+        assertEquals(emptyList<String>(), GeminiClient.parseModelsJson("   "))
+        assertEquals(emptyList<String>(), GeminiClient.parseModelsJson("<html>error</html>"))
+        assertEquals(emptyList<String>(), GeminiClient.parseModelsJson("""{"models":[]}"""))
+        assertEquals(emptyList<String>(), GeminiClient.parseModelsJson("""{"other":1}"""))
+    }
+}

--- a/app/src/test/java/com/musheer360/swiftslate/manager/CommandManagerTest.kt
+++ b/app/src/test/java/com/musheer360/swiftslate/manager/CommandManagerTest.kt
@@ -90,17 +90,17 @@ class CommandManagerTest {
     // --- getCommands ---
 
     @Test
-    fun getCommands_returnsFourteenBuiltInByDefault() {
+    fun getCommands_returnsFifteenBuiltInByDefault() {
         val commands = commandManager.getCommands()
-        assertEquals(14, commands.size)
+        assertEquals(15, commands.size)
     }
 
     @Test
     fun getCommands_systemCommandsHaveIsBuiltInTrue() {
         val commands = commandManager.getCommands()
-        val systemTriggers = listOf("?undo", "?copy", "?cut", "?paste", "?replace")
+        val systemTriggers = listOf("?undo", "?copy", "?cut", "?paste", "?replace", "?translate:XX")
         val systemCommands = commands.filter { it.trigger in systemTriggers }
-        assertEquals(5, systemCommands.size)
+        assertEquals(6, systemCommands.size)
         assertTrue(systemCommands.all { it.isBuiltIn })
     }
 
@@ -117,7 +117,7 @@ class CommandManagerTest {
     fun getCommands_afterAddingCustom_includesIt() {
         commandManager.saveCustomCommand(Command("?myCmd", "do something"))
         val commands = commandManager.getCommands()
-        assertEquals(15, commands.size)
+        assertEquals(16, commands.size)
         assertTrue(commands.any { it.trigger == "?myCmd" })
     }
 

--- a/app/src/test/java/com/musheer360/swiftslate/manager/CommandManagerTest.kt
+++ b/app/src/test/java/com/musheer360/swiftslate/manager/CommandManagerTest.kt
@@ -98,7 +98,7 @@ class CommandManagerTest {
     @Test
     fun getCommands_systemCommandsHaveIsBuiltInTrue() {
         val commands = commandManager.getCommands()
-        val systemTriggers = listOf("?undo", "?copy", "?cut", "?paste", "?replace", "?translate:XX")
+        val systemTriggers = listOf("?undo", "?copy", "?cut", "?paste", "?replace", "?translate:xx")
         val systemCommands = commands.filter { it.trigger in systemTriggers }
         assertEquals(6, systemCommands.size)
         assertTrue(systemCommands.all { it.isBuiltIn })

--- a/app/src/test/java/com/musheer360/swiftslate/model/CatalogTest.kt
+++ b/app/src/test/java/com/musheer360/swiftslate/model/CatalogTest.kt
@@ -15,11 +15,19 @@ class CatalogTest {
     }
 
     @Test
-    fun groq_sanitize_coerces_unknown_and_null_to_default() {
+    fun groq_sanitize_blank_and_retired_to_default_unknown_passes_through() {
         assertEquals(GroqModels.DEFAULT, GroqModels.sanitize(null))
         assertEquals(GroqModels.DEFAULT, GroqModels.sanitize(""))
-        assertEquals(GroqModels.DEFAULT, GroqModels.sanitize("llama-3.3-70b-versatile")) // retired
-        assertEquals(GroqModels.DEFAULT, GroqModels.sanitize("meta-llama/llama-4-scout-17b-16e-instruct")) // removed
+        assertEquals(GroqModels.DEFAULT, GroqModels.sanitize("   "))
+        // Decommissioned by Groq: requests always fail, so migrate.
+        assertEquals(GroqModels.DEFAULT, GroqModels.sanitize("llama-3.3-70b-versatile"))
+        assertEquals(
+            GroqModels.DEFAULT,
+            GroqModels.sanitize(" meta-llama/llama-4-scout-17b-16e-instruct ")
+        )
+        // Dynamic selection (issue #148): off-catalog but live ids pass through trimmed.
+        assertEquals("llama-3.1-8b-instant", GroqModels.sanitize("llama-3.1-8b-instant"))
+        assertEquals("custom/new-model", GroqModels.sanitize(" custom/new-model "))
     }
 
     @Test
@@ -41,15 +49,22 @@ class CatalogTest {
     }
 
     @Test
-    fun groq_labels_present_and_fallback() {
-        for (id in GroqModels.ALL) assertTrue(GroqModels.label(id).isNotBlank())
-        assertEquals("unknown-model", GroqModels.label("unknown-model"))
+    fun groq_isChatCandidate_excludes_non_chat_entries() {
+        assertTrue(GroqModels.isChatCandidate("llama-3.1-8b-instant"))
+        assertTrue(GroqModels.isChatCandidate("openai/gpt-oss-120b"))
+        assertTrue(GroqModels.isChatCandidate("qwen/qwen3.6-27b"))
+        assertFalse(GroqModels.isChatCandidate("whisper-large-v3"))
+        assertFalse(GroqModels.isChatCandidate("distil-whisper-en"))
+        assertFalse(GroqModels.isChatCandidate("playai-tts"))
+        assertFalse(GroqModels.isChatCandidate("groq/playai-tts-qwen"))
+        assertFalse(GroqModels.isChatCandidate("llama-guard-3-8b-8192"))
+        assertFalse(GroqModels.isChatCandidate("meta-llama/llama-guard-4-12b"))
     }
 
     @Test
-    fun groq_options_match_all_ids_in_order() {
-        assertEquals(GroqModels.ALL, GroqModels.OPTIONS.map { it.first })
-        assertTrue(GroqModels.OPTIONS.all { it.second.isNotBlank() })
+    fun groq_labels_present_and_fallback() {
+        for (id in GroqModels.ALL) assertTrue(GroqModels.label(id).isNotBlank())
+        assertEquals("unknown-model", GroqModels.label("unknown-model"))
     }
 
     // ---------- GeminiModels ----------
@@ -61,10 +76,12 @@ class CatalogTest {
     }
 
     @Test
-    fun gemini_sanitize_coerces_unknown_to_default() {
+    fun gemini_sanitize_blank_and_retired_to_default_unknown_passes_through() {
         assertEquals(GeminiModels.DEFAULT, GeminiModels.sanitize(null))
+        assertEquals(GeminiModels.DEFAULT, GeminiModels.sanitize("  "))
         assertEquals(GeminiModels.DEFAULT, GeminiModels.sanitize("gemini-2.5-flash-lite")) // retired (issue #113)
-        for (id in GeminiModels.ALL) assertEquals(id, GeminiModels.sanitize(id))
+        // Dynamic selection (issue #148): unknown-but-live ids pass through trimmed.
+        assertEquals("gemini-3.7-pro-preview", GeminiModels.sanitize(" gemini-3.7-pro-preview "))
     }
 
     @Test
@@ -73,11 +90,5 @@ class CatalogTest {
         assertEquals("low", GeminiModels.thinkingLevel("gemini-3.5-flash-lite"))
         assertEquals("minimal", GeminiModels.thinkingLevel("gemini-3.6-flash"))
         assertNull(GeminiModels.thinkingLevel("gemini-9-ultra"))
-    }
-
-    @Test
-    fun gemini_options_match_all_ids() {
-        assertEquals(GeminiModels.ALL, GeminiModels.OPTIONS.map { it.first })
-        assertTrue(GeminiModels.OPTIONS.all { it.second.isNotBlank() })
     }
 }

--- a/app/src/test/java/com/musheer360/swiftslate/provider/ProviderConfigTest.kt
+++ b/app/src/test/java/com/musheer360/swiftslate/provider/ProviderConfigTest.kt
@@ -72,8 +72,9 @@ class ProviderConfigTest {
     }
 
     @Test
-    fun gemini_config_coerces_model_and_exposes_thinking_level() {
-        assertEquals(GeminiModels.DEFAULT, GeminiConfig.sanitizeModel("gemini-2.5-flash-lite"))
+    fun gemini_config_sanitizes_and_exposes_thinking_level() {
+        assertEquals(GeminiModels.DEFAULT, GeminiConfig.sanitizeModel("gemini-2.5-flash-lite")) // retired
+        assertEquals("gemini-3.7-pro", GeminiConfig.sanitizeModel("  gemini-3.7-pro  ")) // dynamic pass-through
         assertEquals("low", GeminiConfig.thinkingLevel(GeminiModels.DEFAULT))
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-    id("com.android.application") version "9.3.1" apply false
+    id("com.android.application") version "9.3.2" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.4.10" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=84fbba45c7f4c64abc77460e1c00f541e9f960e3c7ed2538f1ede19eacd873ae
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionSha256Sum=acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
## What does this PR do?

Resolves #148. Supersedes and consolidates #153 and all open Dependabot PRs (#149, #150, #156, #157, #158) into a single unified release candidate.

### Real-Time Dynamic Model Dropdown (Gemini & Groq)
- **Instant Dropdown Expansion**: Opening the dropdown menu renders immediately (0ms UI lag) with cached or curated defaults, avoiding freezing.
- **Real-Time On-Open Fetching**: Expanding the dropdown (`onExpandedChange`) triggers a live asynchronous query to the provider's `/models` endpoint in the background.
- **In-Menu Loading Feedback**: While the request is in flight, an elegant inline loader (`CircularProgressIndicator` + `settings_fetch_models_loading`) appears at the top of the menu, followed by a `SlateDivider`. Once fetched, the menu recomposes in place.
- **Strict Read-Only Selection**: Anchored with `SlateTextField(readOnly = true, PrimaryNotEditable)` so users select valid active models without manual typing errors.
- **Bounded & Scrollable**: Constrained to `Modifier.heightIn(max = 300.dp)` with smooth vertical scroll so large catalogs (50+ models) stay compact.
- **100% Theme-Consistent**: Uses SwiftSlate design tokens (`RoundedCornerShape(10.dp)`, `MaterialTheme.colorScheme.surface`, `primary`, `onSurface`, `SlateTextField`, `SlateDivider`).
- **Resilient Fallbacks**: Network failures or offline states preserve fallback/curated presets (`GeminiModels.ALL` and `GroqModels.ALL`) without clearing the list.

### Provider Listing Contracts
- **Gemini (`GET v1beta/models`)**: Implements `GeminiClient.fetchModels(apiKey)`. Checks `supportedGenerationMethods` / `supportedActions` for `"generateContent"`, strips `"models/"` prefix, and safely URL-encodes `nextPageToken` (up to 3 pages).
- **Groq (`GET /openai/v1/models`)**: Probes endpoint via `OpenAICompatibleClient.fetchModels` and filters out audio (`whisper`), TTS (`playai`, `-tts`), and safety classifiers (`guard`) via `GroqModels.isChatCandidate`.
- **Model Normalization (`sanitize`)**: Updates `GeminiModels.sanitize` and `GroqModels.sanitize` to pass through trimmed dynamic IDs while migrating retired IDs (`gemini-2.5-flash-lite`, `llama-3.3-70b-versatile`) to `DEFAULT`.
- **Localization**: All 4 new settings strings translated across all 40+ supported locales.

### Consolidated Dependabot Upgrades
- Bump `androidx.compose:compose-bom` from `2026.06.01` to `2026.08.00` (#149)
- Bump `actions/github-script` from `7.1.0` to `9.0.0` (#150)
- Bump `com.android.application` from `9.3.1` to `9.3.2` (#156)
- Bump `actions/setup-java` from `5.7.0` to `6.0.0` (#157)
- Bump `gradle-wrapper` from `9.7.0` to `9.7.1` (#158)

## Testing
- Unit tests: `GeminiModelsListParserTest`, `CatalogTest`, `ProviderConfigTest`. Full `./gradlew testDebugUnitTest` passing cleanly on Gradle 9.7.1 and AGP 9.3.2.
- Lint verification: `./gradlew :app:lintDebug` passing with 0 errors across all 40+ locales.
- Live API verification: Tested against real Gemini and Groq API endpoints.
