### PR TITLE
fix: adaptive UI rhythm, Android 12-14 key loss, and dependency bumps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -447,7 +447,7 @@ jobs:
         run: echo "$VERSION_CODE" > artifacts/versionCode.txt
 
       - name: Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: ${{ needs.version.outputs.tag }}
           files: |

--- a/app/src/main/java/com/musheer360/swiftslate/MainActivity.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/MainActivity.kt
@@ -12,6 +12,8 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.*
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
@@ -34,6 +36,8 @@ import com.musheer360.swiftslate.ui.CommandsScreen
 import com.musheer360.swiftslate.ui.DashboardScreen
 import com.musheer360.swiftslate.ui.KeysScreen
 import com.musheer360.swiftslate.ui.SettingsScreen
+import com.musheer360.swiftslate.ui.components.LocalSlateRhythm
+import com.musheer360.swiftslate.ui.components.SlateRhythm
 import com.musheer360.swiftslate.ui.theme.SwiftSlateTheme
 
 enum class Tab(@param:StringRes val titleRes: Int, val icon: ImageVector) {
@@ -143,7 +147,16 @@ fun SwiftSlateMainScreen(vm: SwiftSlateViewModel = viewModel()) {
             },
             label = "tab_transition"
         ) { tab ->
-            screens[tab]?.invoke()
+            // One rhythm for every tab, derived from the height the content area
+            // actually has after the nav bar and system insets. Resolving it here
+            // rather than per screen is what keeps padding, gaps and type identical
+            // across Dashboard, Keys, Commands and Settings.
+            BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+                val rhythm = remember(maxHeight) { SlateRhythm.forHeight(maxHeight) }
+                CompositionLocalProvider(LocalSlateRhythm provides rhythm) {
+                    screens[tab]?.invoke()
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/musheer360/swiftslate/manager/KeyCipher.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/manager/KeyCipher.kt
@@ -71,7 +71,22 @@ internal class AndroidKeystoreCipher : KeyCipher {
                             // requiring an unlocked device costs nothing and stops the stored
                             // API keys from being decryptable on a locked device. Applies to
                             // newly generated keys only; existing installs keep theirs.
-                            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+                            //
+                            // Gated to Android 15+ on Google's own advice (issue #141). Android
+                            // 12, 13 and 14 ship a platform bug where keys carrying this flag
+                            // cannot be generated, imported or used at all unless a secure lock
+                            // screen is set, and are silently deleted if the user later removes
+                            // it. Both failures are terminal here: generation throws, so
+                            // [available] goes false and no key can ever be saved; and deletion
+                            // makes the stored blob undecryptable, so getKeys() returns empty
+                            // and the user's keys are simply gone. Enabling it below API 35
+                            // trades a locked-device hardening win for total key loss on three
+                            // major versions.
+                            //
+                            // See KeyGenParameterSpec.Builder#setUnlockedDeviceRequired.
+                            if (android.os.Build.VERSION.SDK_INT >=
+                                android.os.Build.VERSION_CODES.VANILLA_ICE_CREAM
+                            ) {
                                 setUnlockedDeviceRequired(true)
                             }
                         }

--- a/app/src/main/java/com/musheer360/swiftslate/ui/CommandsScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/CommandsScreen.kt
@@ -39,6 +39,7 @@ import com.musheer360.swiftslate.R
 import com.musheer360.swiftslate.manager.CommandManager
 import com.musheer360.swiftslate.model.Command
 import com.musheer360.swiftslate.model.CommandType
+import com.musheer360.swiftslate.ui.components.LocalSlateRhythm
 import com.musheer360.swiftslate.ui.components.ScreenTitle
 import com.musheer360.swiftslate.ui.components.SlateCard
 import com.musheer360.swiftslate.ui.components.SlateItemCard
@@ -84,11 +85,13 @@ fun CommandsScreen(commandManager: CommandManager) {
         label = "chevron"
     )
 
+    val rhythm = LocalSlateRhythm.current
+
     Column(
         modifier = Modifier
             .fillMaxSize()
             .graphicsLayer { }
-            .padding(horizontal = 20.dp, vertical = 16.dp)
+            .padding(horizontal = rhythm.screenPaddingH, vertical = rhythm.screenPaddingV)
     ) {
         ScreenTitle(stringResource(R.string.commands_title))
 
@@ -98,7 +101,7 @@ fun CommandsScreen(commandManager: CommandManager) {
             Surface(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 8.dp)
+                    .padding(bottom = rhythm.cardGap)
                     .semantics { contentDescription = searchLabel },
                 shape = RoundedCornerShape(10.dp),
                 color = MaterialTheme.colorScheme.surface
@@ -122,7 +125,7 @@ fun CommandsScreen(commandManager: CommandManager) {
                         onValueChange = { searchQuery = it },
                         singleLine = true,
                         textStyle = LocalTextStyle.current.copy(
-                            fontSize = 15.sp,
+                            fontSize = rhythm.emphasisSize,
                             fontWeight = FontWeight.Medium,
                             color = MaterialTheme.colorScheme.onSurface
                         ),
@@ -133,7 +136,7 @@ fun CommandsScreen(commandManager: CommandManager) {
                                 if (searchQuery.isEmpty()) {
                                     Text(
                                         text = searchLabel,
-                                        fontSize = 15.sp,
+                                        fontSize = rhythm.emphasisSize,
                                         fontWeight = FontWeight.Medium,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant
                                     )
@@ -177,14 +180,14 @@ fun CommandsScreen(commandManager: CommandManager) {
             SlateCard(modifier = Modifier.weight(1f)) {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(8.dp)),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(rhythm.listGap),
                     contentPadding = PaddingValues(bottom = 4.dp)
                 ) {
                     if (filteredCommands.isEmpty() && searchQuery.isNotBlank()) {
                         item {
                             Text(
                                 text = stringResource(R.string.commands_search_empty),
-                                fontSize = 13.sp,
+                                fontSize = rhythm.bodySize,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
                                 textAlign = TextAlign.Center
@@ -209,14 +212,14 @@ fun CommandsScreen(commandManager: CommandManager) {
                                     Text(
                                         text = cmd.trigger,
                                         fontWeight = FontWeight.Bold,
-                                        fontSize = 15.sp,
+                                        fontSize = rhythm.emphasisSize,
                                         color = MaterialTheme.colorScheme.primary
                                     )
                                     if (!cmd.isBuiltIn) {
                                         Spacer(modifier = Modifier.weight(1f))
                                         Text(
                                             text = stringResource(R.string.commands_edit_command),
-                                            fontSize = 13.sp,
+                                            fontSize = rhythm.bodySize,
                                             fontWeight = FontWeight.Medium,
                                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                                             modifier = Modifier.clickable(
@@ -234,12 +237,12 @@ fun CommandsScreen(commandManager: CommandManager) {
                                         )
                                         Text(
                                             text = " | ",
-                                            fontSize = 13.sp,
+                                            fontSize = rhythm.bodySize,
                                             color = MaterialTheme.colorScheme.primary
                                         )
                                         Text(
                                             text = stringResource(R.string.commands_delete_command),
-                                            fontSize = 13.sp,
+                                            fontSize = rhythm.bodySize,
                                             fontWeight = FontWeight.Medium,
                                             color = MaterialTheme.colorScheme.error,
                                             modifier = Modifier.clickable(
@@ -254,7 +257,7 @@ fun CommandsScreen(commandManager: CommandManager) {
                                         Spacer(modifier = Modifier.weight(1f))
                                         Text(
                                             text = stringResource(R.string.commands_built_in),
-                                            fontSize = 13.sp,
+                                            fontSize = rhythm.bodySize,
                                             fontWeight = FontWeight.Medium,
                                             color = MaterialTheme.colorScheme.onSurfaceVariant
                                         )
@@ -272,10 +275,10 @@ fun CommandsScreen(commandManager: CommandManager) {
                                     ) + fadeOut(tween(150))
                                 ) {
                                     Column {
-                                        Spacer(modifier = Modifier.height(8.dp))
+                                        Spacer(modifier = Modifier.height(rhythm.formGap))
                                         Text(
                                             text = cmd.prompt,
-                                            fontSize = 13.sp,
+                                            fontSize = rhythm.bodySize,
                                             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
                                         )
                                     }
@@ -289,7 +292,7 @@ fun CommandsScreen(commandManager: CommandManager) {
             Spacer(modifier = Modifier.weight(1f))
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(rhythm.cardGap))
 
         // Collapsible form card — at the bottom
         SlateCard {
@@ -309,7 +312,7 @@ fun CommandsScreen(commandManager: CommandManager) {
             ) {
                 Text(
                     text = stringResource(R.string.commands_add_custom_title),
-                    fontSize = 15.sp,
+                    fontSize = rhythm.emphasisSize,
                     fontWeight = FontWeight.Medium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -333,7 +336,7 @@ fun CommandsScreen(commandManager: CommandManager) {
                 ) + fadeOut(tween(150))
             ) {
                 Column {
-                    Spacer(modifier = Modifier.height(12.dp))
+                    Spacer(modifier = Modifier.height(rhythm.groupGap))
                     SingleChoiceSegmentedButtonRow(
                         modifier = Modifier.fillMaxWidth()
                     ) {
@@ -374,7 +377,7 @@ fun CommandsScreen(commandManager: CommandManager) {
                             Text(stringResource(R.string.commands_type_replacer))
                         }
                     }
-                    Spacer(modifier = Modifier.height(12.dp))
+                    Spacer(modifier = Modifier.height(rhythm.groupGap))
                     SlateTextField(
                         value = trigger,
                         onValueChange = {
@@ -391,7 +394,7 @@ fun CommandsScreen(commandManager: CommandManager) {
                         label = { Text(stringResource(R.string.commands_trigger_label, prefix)) },
                         singleLine = true
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(rhythm.formGap))
                     SlateTextField(
                         value = prompt,
                         onValueChange = {
@@ -408,11 +411,11 @@ fun CommandsScreen(commandManager: CommandManager) {
                         Text(
                             text = msg,
                             color = MaterialTheme.colorScheme.error,
-                            fontSize = 13.sp,
-                            modifier = Modifier.padding(top = 8.dp)
+                            fontSize = rhythm.bodySize,
+                            modifier = Modifier.padding(top = rhythm.formGap)
                         )
                     }
-                    Spacer(modifier = Modifier.height(12.dp))
+                    Spacer(modifier = Modifier.height(rhythm.groupGap))
                     if (editingTrigger != null) {
                         TextButton(
                             onClick = {

--- a/app/src/main/java/com/musheer360/swiftslate/ui/DashboardScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/DashboardScreen.kt
@@ -32,6 +32,7 @@ import com.musheer360.swiftslate.SwiftSlateApp
 import com.musheer360.swiftslate.manager.CommandManager
 import com.musheer360.swiftslate.manager.KeyManager
 import com.musheer360.swiftslate.manager.StatsManager
+import com.musheer360.swiftslate.ui.components.LocalSlateRhythm
 import com.musheer360.swiftslate.ui.components.ScreenTitle
 import com.musheer360.swiftslate.ui.components.SlateCard
 import com.musheer360.swiftslate.ui.components.SlateDivider
@@ -138,12 +139,13 @@ fun DashboardScreen(keyManager: KeyManager, commandManager: CommandManager, stat
     }
 
     val noData = stringResource(R.string.dashboard_no_data)
+    val rhythm = LocalSlateRhythm.current
 
     Column(
         modifier = Modifier
             .fillMaxSize()
             .graphicsLayer { }
-            .padding(horizontal = 20.dp, vertical = 16.dp)
+            .padding(horizontal = rhythm.screenPaddingH, vertical = rhythm.screenPaddingV)
     ) {
         ScreenTitle(stringResource(R.string.dashboard_title))
 
@@ -168,7 +170,7 @@ fun DashboardScreen(keyManager: KeyManager, commandManager: CommandManager, stat
                     Text(
                         text = if (isServiceEnabled) stringResource(R.string.service_status_active)
                         else stringResource(R.string.service_status_inactive),
-                        fontSize = 15.sp,
+                        fontSize = rhythm.emphasisSize,
                         fontWeight = FontWeight.Medium,
                         color = MaterialTheme.colorScheme.onSurface
                     )
@@ -187,9 +189,9 @@ fun DashboardScreen(keyManager: KeyManager, commandManager: CommandManager, stat
                 }
             }
 
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(rhythm.groupGap))
             SlateDivider()
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(rhythm.groupGap))
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -197,12 +199,12 @@ fun DashboardScreen(keyManager: KeyManager, commandManager: CommandManager, stat
             ) {
                 Text(
                     text = stringResource(R.string.dashboard_api_keys_title),
-                    fontSize = 13.sp,
+                    fontSize = rhythm.bodySize,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Text(
                     text = stringResource(R.string.dashboard_keys_configured, keyCount),
-                    fontSize = 15.sp,
+                    fontSize = rhythm.emphasisSize,
                     fontWeight = FontWeight.Medium,
                     color = MaterialTheme.colorScheme.onSurface
                 )
@@ -211,33 +213,33 @@ fun DashboardScreen(keyManager: KeyManager, commandManager: CommandManager, stat
                 Text(
                     text = stringResource(R.string.dashboard_add_key_hint),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    fontSize = 13.sp,
-                    modifier = Modifier.padding(top = 8.dp)
+                    fontSize = rhythm.bodySize,
+                    modifier = Modifier.padding(top = rhythm.formGap)
                 )
             }
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(rhythm.cardGap))
 
         // Interrupted-service banner: the toggle can still read "on" while the process is dead.
         if (showKilledBanner) {
             SlateCard {
                 Text(
                     text = stringResource(R.string.dashboard_service_killed_title),
-                    fontSize = 15.sp,
+                    fontSize = rhythm.emphasisSize,
                     fontWeight = FontWeight.Medium,
                     color = MaterialTheme.colorScheme.error
                 )
-                Spacer(modifier = Modifier.height(4.dp))
+                Spacer(modifier = Modifier.height(rhythm.tightGap))
                 Text(
                     text = stringResource(R.string.dashboard_service_killed_message),
-                    fontSize = 13.sp,
+                    fontSize = rhythm.bodySize,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                Spacer(modifier = Modifier.height(12.dp))
+                Spacer(modifier = Modifier.height(rhythm.groupGap))
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    horizontalArrangement = Arrangement.spacedBy(rhythm.groupGap)
                 ) {
                     Button(
                         onClick = {
@@ -262,7 +264,7 @@ fun DashboardScreen(keyManager: KeyManager, commandManager: CommandManager, stat
                     }
                 }
             }
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(rhythm.cardGap))
         }
 
         // Usage statistics card
@@ -275,42 +277,42 @@ fun DashboardScreen(keyManager: KeyManager, commandManager: CommandManager, stat
                 Column(horizontalAlignment = Alignment.Start) {
                     Text(
                         text = "$monthlyRequests",
-                        fontSize = 24.sp,
+                        fontSize = rhythm.statSize,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.primary
                     )
                     Text(
                         text = stringResource(R.string.dashboard_monthly_requests),
-                        fontSize = 12.sp,
+                        fontSize = rhythm.captionSize,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
                 Column(horizontalAlignment = Alignment.End) {
                     Text(
                         text = favoriteCommand ?: noData,
-                        fontSize = 24.sp,
+                        fontSize = rhythm.statSize,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.primary
                     )
                     Text(
                         text = stringResource(R.string.dashboard_favorite_command),
-                        fontSize = 12.sp,
+                        fontSize = rhythm.captionSize,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
             }
 
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(rhythm.groupGap))
             SlateDivider()
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(rhythm.groupGap))
 
             // 7-day bar chart
             Text(
                 text = stringResource(R.string.dashboard_last_7_days),
-                fontSize = 13.sp,
+                fontSize = rhythm.bodySize,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(rhythm.formGap))
 
             val maxCount = dailyCounts.maxOfOrNull { it.second } ?: 0
             val dayNameFmt = remember { SimpleDateFormat("EEE", Locale.getDefault()) }
@@ -338,7 +340,7 @@ fun DashboardScreen(keyManager: KeyManager, commandManager: CommandManager, stat
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             textAlign = TextAlign.Center
                         )
-                        Spacer(modifier = Modifier.height(4.dp))
+                        Spacer(modifier = Modifier.height(rhythm.tightGap))
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -353,7 +355,7 @@ fun DashboardScreen(keyManager: KeyManager, commandManager: CommandManager, stat
                                     .background(MaterialTheme.colorScheme.primary)
                             )
                         }
-                        Spacer(modifier = Modifier.height(4.dp))
+                        Spacer(modifier = Modifier.height(rhythm.tightGap))
                         Text(
                             text = dayLabel,
                             fontSize = 10.sp,

--- a/app/src/main/java/com/musheer360/swiftslate/ui/KeysScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/KeysScreen.kt
@@ -34,6 +34,7 @@ import com.musheer360.swiftslate.manager.KeyManager
 import com.musheer360.swiftslate.model.PrefKeys
 import com.musheer360.swiftslate.model.ProviderType
 import com.musheer360.swiftslate.provider.GroqConfig
+import com.musheer360.swiftslate.ui.components.LocalSlateRhythm
 import com.musheer360.swiftslate.ui.components.ScreenTitle
 import com.musheer360.swiftslate.ui.components.SlateCard
 import com.musheer360.swiftslate.ui.components.SlateItemCard
@@ -71,12 +72,13 @@ fun KeysScreen(keyManager: KeyManager, prefs: SharedPreferences) {
     val customEndpointRequiredMsg = stringResource(R.string.keys_custom_endpoint_required)
     val signinRequiredMsg = stringResource(R.string.error_provider_auth_required)
     val endpointNeedsV1Msg = stringResource(R.string.keys_endpoint_needs_v1)
+    val rhythm = LocalSlateRhythm.current
 
     Column(
         modifier = Modifier
             .fillMaxSize()
             .graphicsLayer { } // Creates a hardware layer for smooth NavHost slide animations
-            .padding(horizontal = 20.dp, vertical = 16.dp)
+            .padding(horizontal = rhythm.screenPaddingH, vertical = rhythm.screenPaddingV)
     ) {
         ScreenTitle(stringResource(R.string.keys_title))
 
@@ -85,10 +87,10 @@ fun KeysScreen(keyManager: KeyManager, prefs: SharedPreferences) {
                 Text(
                     text = keystoreErrorMsg,
                     color = MaterialTheme.colorScheme.error,
-                    fontSize = 13.sp
+                    fontSize = rhythm.bodySize
                 )
             }
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(rhythm.cardGap))
         }
 
         SlateCard {
@@ -99,7 +101,7 @@ fun KeysScreen(keyManager: KeyManager, prefs: SharedPreferences) {
                 singleLine = true,
                 visualTransformation = PasswordVisualTransformation()
             )
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(rhythm.groupGap))
             Button(
                 onClick = {
                     if (newKey.isNotBlank()) {
@@ -178,8 +180,8 @@ fun KeysScreen(keyManager: KeyManager, prefs: SharedPreferences) {
                 Text(
                     text = testResult!!,
                     color = if (testSuccess) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.error,
-                    fontSize = 13.sp,
-                    modifier = Modifier.padding(top = 8.dp)
+                    fontSize = rhythm.bodySize,
+                    modifier = Modifier.padding(top = rhythm.formGap)
                 )
             }
             val (apiKeyUrl, providerName) = when (prefs.getString(PrefKeys.PROVIDER_TYPE, ProviderType.GEMINI) ?: ProviderType.GEMINI) {
@@ -191,21 +193,21 @@ fun KeysScreen(keyManager: KeyManager, prefs: SharedPreferences) {
                 Text(
                     text = stringResource(R.string.keys_get_api_key, providerName),
                     color = MaterialTheme.colorScheme.primary,
-                    fontSize = 13.sp,
+                    fontSize = rhythm.bodySize,
                     modifier = Modifier
                         .clickable(interactionSource = null, indication = null) { uriHandler.openUri(apiKeyUrl) }
-                        .padding(top = 8.dp)
+                        .padding(top = rhythm.formGap)
                 )
             }
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(rhythm.cardGap))
 
         if (keys.isNotEmpty()) {
             SlateCard(modifier = Modifier.weight(1f)) {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(8.dp)),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(rhythm.listGap),
                     contentPadding = PaddingValues(bottom = 4.dp)
                 ) {
                     itemsIndexed(keys, key = { index, k -> "$index-${k.hashCode()}" }) { index, key ->
@@ -213,13 +215,13 @@ fun KeysScreen(keyManager: KeyManager, prefs: SharedPreferences) {
                             Text(
                                 text = "••••••••" + key.takeLast(4),
                                 fontWeight = FontWeight.Medium,
-                                fontSize = 15.sp,
+                                fontSize = rhythm.emphasisSize,
                                 color = MaterialTheme.colorScheme.onSurface,
                                 modifier = Modifier.weight(1f).semantics(mergeDescendants = true) {}
                             )
                             Text(
                                 text = stringResource(R.string.delete_confirm_button),
-                                fontSize = 13.sp,
+                                fontSize = rhythm.bodySize,
                                 fontWeight = FontWeight.Medium,
                                 color = MaterialTheme.colorScheme.error,
                                 modifier = Modifier.clickable(
@@ -242,7 +244,7 @@ fun KeysScreen(keyManager: KeyManager, prefs: SharedPreferences) {
                 ) {
                     Text(
                         text = stringResource(R.string.keys_empty),
-                        fontSize = 13.sp,
+                        fontSize = rhythm.bodySize,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }

--- a/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
@@ -40,6 +40,7 @@ import com.musheer360.swiftslate.model.PrefKeys
 import com.musheer360.swiftslate.model.ProviderType
 import com.musheer360.swiftslate.provider.EndpointValidator
 import com.musheer360.swiftslate.provider.GroqConfig
+import com.musheer360.swiftslate.ui.components.LocalSlateRhythm
 import com.musheer360.swiftslate.ui.components.ScreenTitle
 import com.musheer360.swiftslate.ui.components.SlateCard
 import com.musheer360.swiftslate.ui.components.SlateDivider
@@ -242,11 +243,13 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
         }
     }
 
+    val rhythm = LocalSlateRhythm.current
+
     Column(
         modifier = Modifier
             .fillMaxSize()
             .graphicsLayer { }
-            .padding(horizontal = 20.dp, vertical = 16.dp)
+            .padding(horizontal = rhythm.screenPaddingH, vertical = rhythm.screenPaddingV)
     ) {
         ScreenTitle(stringResource(R.string.settings_title))
 
@@ -254,10 +257,10 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
         SlateCard {
             Text(
                 text = stringResource(R.string.settings_provider_title),
-                fontSize = 13.sp,
+                fontSize = rhythm.bodySize,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(rhythm.formGap))
             ExposedDropdownMenuBox(
                 expanded = providerExpanded,
                 onExpandedChange = { providerExpanded = !providerExpanded }
@@ -308,14 +311,14 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     )
                 }
             }
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(rhythm.formGap))
             if (providerType == ProviderType.GEMINI) {
                 Text(
                     text = stringResource(R.string.settings_model_title),
-                    fontSize = 13.sp,
+                    fontSize = rhythm.bodySize,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(rhythm.formGap))
                 DynamicModelDropdown(
                     selectedLabel = if (apiKeys.isEmpty() || selectedModel.isBlank()) "" else GeminiModels.label(selectedModel),
                     enabled = apiKeys.isNotEmpty(),
@@ -341,10 +344,10 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
             } else if (providerType == ProviderType.GROQ) {
                 Text(
                     text = stringResource(R.string.settings_model_title),
-                    fontSize = 13.sp,
+                    fontSize = rhythm.bodySize,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(rhythm.formGap))
                 DynamicModelDropdown(
                     selectedLabel = if (apiKeys.isEmpty() || groqModel.isBlank()) "" else GroqModels.label(groqModel),
                     enabled = apiKeys.isNotEmpty(),
@@ -370,10 +373,10 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
             } else {
                 Text(
                     text = stringResource(R.string.settings_endpoint_title),
-                    fontSize = 13.sp,
+                    fontSize = rhythm.bodySize,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(rhythm.formGap))
                 SlateTextField(
                     value = customEndpoint,
                     onValueChange = {
@@ -404,17 +407,17 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     Text(
                         text = msg,
                         color = MaterialTheme.colorScheme.error,
-                        fontSize = 13.sp,
-                        modifier = Modifier.padding(top = 8.dp)
+                        fontSize = rhythm.bodySize,
+                        modifier = Modifier.padding(top = rhythm.formGap)
                     )
                 }
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(rhythm.formGap))
                 Text(
                     text = stringResource(R.string.settings_model_title),
-                    fontSize = 13.sp,
+                    fontSize = rhythm.bodySize,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(rhythm.formGap))
                 if (customModels.isNotEmpty()) {
                     ExposedDropdownMenuBox(
                         expanded = customModelExpanded,
@@ -519,30 +522,30 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     Text(
                         text = msg,
                         color = if (fetchSuccess) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.onSurfaceVariant,
-                        fontSize = 13.sp,
-                        modifier = Modifier.padding(top = 4.dp)
+                        fontSize = rhythm.bodySize,
+                        modifier = Modifier.padding(top = rhythm.tightGap)
                     )
                 }
             }
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(rhythm.formGap))
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
                     text = stringResource(R.string.settings_temperature_title),
-                    fontSize = 13.sp,
+                    fontSize = rhythm.bodySize,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Spacer(modifier = Modifier.weight(1f))
                 Text(
                     text = String.format("%.1f", temperature),
-                    fontSize = 15.sp,
+                    fontSize = rhythm.emphasisSize,
                     fontWeight = FontWeight.Medium,
                     color = MaterialTheme.colorScheme.onSurface
                 )
             }
-            Spacer(modifier = Modifier.height(10.dp))
+            Spacer(modifier = Modifier.height(rhythm.sliderGap))
             Slider(
                 value = temperature,
                 onValueChange = {
@@ -557,17 +560,17 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 },
                 valueRange = 0f..2f,
                 steps = 19,
-                modifier = Modifier.fillMaxWidth().height(26.dp),
+                modifier = Modifier.fillMaxWidth().height(rhythm.sliderHeight),
                 colors = SliderDefaults.colors(
                     thumbColor = MaterialTheme.colorScheme.primary,
                     activeTrackColor = MaterialTheme.colorScheme.primary,
                     inactiveTrackColor = MaterialTheme.colorScheme.outline
                 )
             )
-            Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(rhythm.tightGap))
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(rhythm.cardGap))
 
         // Card 2: Trigger Prefix
         SlateCard {
@@ -578,7 +581,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
             ) {
                 Text(
                     text = stringResource(R.string.settings_trigger_prefix_desc, triggerPrefix),
-                    fontSize = 13.sp,
+                    fontSize = rhythm.bodySize,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.weight(1f).padding(end = 16.dp)
                 )
@@ -606,22 +609,22 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 Text(
                     text = msg,
                     color = MaterialTheme.colorScheme.error,
-                    fontSize = 13.sp,
-                    modifier = Modifier.padding(top = 8.dp)
+                    fontSize = rhythm.bodySize,
+                    modifier = Modifier.padding(top = rhythm.formGap)
                 )
             }
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(rhythm.cardGap))
 
         // Card 3: Backup
         SlateCard {
             Text(
                 text = stringResource(R.string.backup_desc),
-                fontSize = 13.sp,
+                fontSize = rhythm.bodySize,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(rhythm.groupGap))
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
@@ -653,48 +656,70 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 Text(
                     text = msg,
                     color = if (backupSuccess) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.error,
-                    fontSize = 13.sp,
-                    modifier = Modifier.padding(top = 8.dp)
+                    fontSize = rhythm.bodySize,
+                    modifier = Modifier.padding(top = rhythm.formGap)
                 )
             }
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(rhythm.cardGap))
 
-        // Card 4: About
-        SlateCard(modifier = Modifier.weight(1f), fillHeight = true) {
-            Text(
-                text = stringResource(R.string.app_name) + " v" + BuildConfig.VERSION_NAME,
-                fontSize = 15.sp,
-                fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = stringResource(R.string.settings_check_updates),
-                fontSize = 13.sp,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.clickable(interactionSource = null, indication = null) {
-                    uriHandler.openUri("https://github.com/Musheer360/SwiftSlate/releases/latest")
-                }
-            )
-            Spacer(modifier = Modifier.weight(1f))
+        // Card 4: About. The only weighted child, so its bottom edge lands flush
+        // screenPaddingV above the nav bar exactly like the last card on every
+        // other tab, and it absorbs whatever slack the rhythm above did not take.
+        //
+        // That slack is split rather than pooled. The two text groups each sit in
+        // an equally weighted half, so the divider lands on the card's midline and
+        // each group is centred within its own half. Pooling it instead — whether
+        // as weighted spacers hugging the divider (which opened a ~104 dp void on
+        // tall screens) or as one centred block (which left dead space above the
+        // version line and below the sponsor line) — is what this replaces.
+        SlateCard(
+            modifier = Modifier.weight(1f),
+            fillHeight = true
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.Center
+            ) {
+                Text(
+                    text = stringResource(R.string.app_name) + " v" + BuildConfig.VERSION_NAME,
+                    fontSize = rhythm.emphasisSize,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(modifier = Modifier.height(rhythm.tightGap))
+                Text(
+                    text = stringResource(R.string.settings_check_updates),
+                    fontSize = rhythm.bodySize,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.clickable(interactionSource = null, indication = null) {
+                        uriHandler.openUri("https://github.com/Musheer360/SwiftSlate/releases/latest")
+                    }
+                )
+            }
+            Spacer(modifier = Modifier.height(rhythm.groupGap))
             SlateDivider()
-            Spacer(modifier = Modifier.weight(1f))
-            Text(
-                text = stringResource(R.string.settings_made_by),
-                fontSize = 13.sp,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = stringResource(R.string.settings_sponsor),
-                fontSize = 13.sp,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.clickable(interactionSource = null, indication = null) {
-                    uriHandler.openUri("https://github.com/sponsors/Musheer360")
-                }
-            )
+            Spacer(modifier = Modifier.height(rhythm.groupGap))
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.Center
+            ) {
+                Text(
+                    text = stringResource(R.string.settings_made_by),
+                    fontSize = rhythm.bodySize,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(rhythm.tightGap))
+                Text(
+                    text = stringResource(R.string.settings_sponsor),
+                    fontSize = rhythm.bodySize,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.clickable(interactionSource = null, indication = null) {
+                        uriHandler.openUri("https://github.com/sponsors/Musheer360")
+                    }
+                )
+            }
         }
     }
 
@@ -739,6 +764,7 @@ private fun DynamicModelDropdown(
     isFetching: Boolean,
     fetchingText: String
 ) {
+    val rhythm = LocalSlateRhythm.current
     ExposedDropdownMenuBox(
         expanded = expanded && enabled,
         onExpandedChange = { if (enabled) onExpandedChange(it) }
@@ -773,7 +799,7 @@ private fun DynamicModelDropdown(
                                 Spacer(modifier = Modifier.width(10.dp))
                                 Text(
                                     text = fetchingText,
-                                    fontSize = 13.sp,
+                                    fontSize = rhythm.bodySize,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
                             }

--- a/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
@@ -257,7 +257,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 fontSize = 13.sp,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(8.dp))
             ExposedDropdownMenuBox(
                 expanded = providerExpanded,
                 onExpandedChange = { providerExpanded = !providerExpanded }
@@ -308,14 +308,14 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     )
                 }
             }
-            Spacer(modifier = Modifier.height(6.dp))
+            Spacer(modifier = Modifier.height(8.dp))
             if (providerType == ProviderType.GEMINI) {
                 Text(
                     text = stringResource(R.string.settings_model_title),
                     fontSize = 13.sp,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                Spacer(modifier = Modifier.height(4.dp))
+                Spacer(modifier = Modifier.height(8.dp))
                 DynamicModelDropdown(
                     selectedLabel = if (apiKeys.isEmpty() || selectedModel.isBlank()) "" else GeminiModels.label(selectedModel),
                     enabled = apiKeys.isNotEmpty(),
@@ -344,7 +344,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     fontSize = 13.sp,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                Spacer(modifier = Modifier.height(6.dp))
+                Spacer(modifier = Modifier.height(8.dp))
                 DynamicModelDropdown(
                     selectedLabel = if (apiKeys.isEmpty() || groqModel.isBlank()) "" else GroqModels.label(groqModel),
                     enabled = apiKeys.isNotEmpty(),
@@ -542,7 +542,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     color = MaterialTheme.colorScheme.onSurface
                 )
             }
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(10.dp))
             Slider(
                 value = temperature,
                 onValueChange = {
@@ -564,10 +564,10 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                     inactiveTrackColor = MaterialTheme.colorScheme.outline
                 )
             )
-            Spacer(modifier = Modifier.height(6.dp))
+            Spacer(modifier = Modifier.height(4.dp))
         }
 
-        Spacer(modifier = Modifier.height(6.dp))
+        Spacer(modifier = Modifier.height(8.dp))
 
         // Card 2: Trigger Prefix
         SlateCard {
@@ -612,7 +612,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
             }
         }
 
-        Spacer(modifier = Modifier.height(6.dp))
+        Spacer(modifier = Modifier.height(8.dp))
 
         // Card 3: Backup
         SlateCard {
@@ -621,7 +621,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 fontSize = 13.sp,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Spacer(modifier = Modifier.height(6.dp))
+            Spacer(modifier = Modifier.height(12.dp))
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
@@ -633,7 +633,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                         exportLauncher.launch("swiftslate-commands.json")
                     },
                     shape = RoundedCornerShape(10.dp),
-                    modifier = Modifier.weight(1f).heightIn(min = 40.dp)
+                    modifier = Modifier.weight(1f).heightIn(min = 48.dp)
                 ) {
                     Text(stringResource(R.string.backup_export))
                 }
@@ -644,7 +644,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                         showImportConfirm = true
                     },
                     shape = RoundedCornerShape(10.dp),
-                    modifier = Modifier.weight(1f).heightIn(min = 40.dp)
+                    modifier = Modifier.weight(1f).heightIn(min = 48.dp)
                 ) {
                     Text(stringResource(R.string.backup_import))
                 }
@@ -659,7 +659,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
             }
         }
 
-        Spacer(modifier = Modifier.height(6.dp))
+        Spacer(modifier = Modifier.height(8.dp))
 
         // Card 4: About
         SlateCard(modifier = Modifier.weight(1f), fillHeight = true) {
@@ -669,7 +669,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 fontWeight = FontWeight.Medium,
                 color = MaterialTheme.colorScheme.onSurface
             )
-            Spacer(modifier = Modifier.height(3.dp))
+            Spacer(modifier = Modifier.height(4.dp))
             Text(
                 text = stringResource(R.string.settings_check_updates),
                 fontSize = 13.sp,
@@ -686,7 +686,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 fontSize = 13.sp,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Spacer(modifier = Modifier.height(3.dp))
+            Spacer(modifier = Modifier.height(4.dp))
             Text(
                 text = stringResource(R.string.settings_sponsor),
                 fontSize = 13.sp,

--- a/app/src/main/java/com/musheer360/swiftslate/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/components/CommonComponents.kt
@@ -7,13 +7,22 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 
+/**
+ * @param contentPadding inner padding. Defaults to the shared [SlateRhythm] so every
+ *   card on every tab agrees; pass a value only to deliberately deviate.
+ * @param verticalArrangement how children are distributed. Only meaningful together
+ *   with [fillHeight].
+ */
 @Composable
 fun SlateCard(
     modifier: Modifier = Modifier,
     fillHeight: Boolean = false,
+    contentPadding: Dp = LocalSlateRhythm.current.cardPadding,
+    verticalArrangement: Arrangement.Vertical = Arrangement.Top,
     content: @Composable ColumnScope.() -> Unit
 ) {
     Surface(
@@ -24,21 +33,30 @@ fun SlateCard(
     ) {
         Column(
             modifier = Modifier
-                .padding(14.dp)
+                .padding(contentPadding)
                 .then(if (fillHeight) Modifier.fillMaxHeight() else Modifier),
+            verticalArrangement = verticalArrangement,
             content = content
         )
     }
 }
 
+/**
+ * The page heading. Size and the gap below it come from the shared [SlateRhythm], so
+ * all four tabs start at the same baseline and their first cards line up.
+ */
 @Composable
-fun ScreenTitle(title: String) {
+fun ScreenTitle(
+    title: String,
+    fontSize: TextUnit = LocalSlateRhythm.current.titleSize,
+    bottomPadding: Dp = LocalSlateRhythm.current.titleGap
+) {
     Text(
         text = title,
-        fontSize = 32.sp,
+        fontSize = fontSize,
         fontWeight = FontWeight.Bold,
         color = MaterialTheme.colorScheme.onBackground,
-        modifier = Modifier.padding(bottom = 20.dp)
+        modifier = Modifier.padding(bottom = bottomPadding)
     )
 }
 
@@ -83,6 +101,7 @@ fun SlateDivider() {
 @Composable
 fun SlateItemCard(
     modifier: Modifier = Modifier,
+    contentPadding: Dp = LocalSlateRhythm.current.itemPadding,
     content: @Composable RowScope.() -> Unit
 ) {
     Surface(
@@ -91,7 +110,7 @@ fun SlateItemCard(
         color = MaterialTheme.colorScheme.surfaceVariant
     ) {
         Row(
-            modifier = Modifier.padding(12.dp),
+            modifier = Modifier.padding(contentPadding),
             verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
             content = content
         )

--- a/app/src/main/java/com/musheer360/swiftslate/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/components/CommonComponents.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.unit.sp
 fun SlateCard(
     modifier: Modifier = Modifier,
     fillHeight: Boolean = false,
-    contentPadding: PaddingValues = PaddingValues(12.dp),
     content: @Composable ColumnScope.() -> Unit
 ) {
     Surface(
@@ -25,7 +24,7 @@ fun SlateCard(
     ) {
         Column(
             modifier = Modifier
-                .padding(contentPadding)
+                .padding(14.dp)
                 .then(if (fillHeight) Modifier.fillMaxHeight() else Modifier),
             content = content
         )
@@ -39,7 +38,7 @@ fun ScreenTitle(title: String) {
         fontSize = 32.sp,
         fontWeight = FontWeight.Bold,
         color = MaterialTheme.colorScheme.onBackground,
-        modifier = Modifier.padding(bottom = 12.dp)
+        modifier = Modifier.padding(bottom = 20.dp)
     )
 }
 

--- a/app/src/main/java/com/musheer360/swiftslate/ui/components/SlateRhythm.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/components/SlateRhythm.kt
@@ -1,0 +1,121 @@
+package com.musheer360.swiftslate.ui.components
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * The one vertical rhythm every tab is laid out on.
+ *
+ * Each tab fits a single viewport with no root scroll and its last card anchored
+ * flush [screenPaddingV] above the nav bar, so the four cards share a fixed height
+ * budget that varies by roughly 120 dp between phones: a Galaxy S23 gives the
+ * content area ~697 dp, a Nothing Phone 2a ~821 dp. One rigid set of tokens cannot
+ * serve both — at 14 dp padding the S23 was ~43 dp short and clipped the bottom
+ * card, while the 2a had ~81 dp spare that piled up into a single void.
+ *
+ * So the tokens interpolate against the available height: short viewports compact
+ * every gap until everything fits, tall viewports let all cards breathe by the
+ * same amount. Because a single instance is provided for the whole app through
+ * [LocalSlateRhythm], every tab necessarily agrees on padding, gaps and type — the
+ * tabs cannot drift apart the way they do with per-screen hardcoded dp values.
+ *
+ * Deliberately fixed, because they are structural rather than cosmetic:
+ * [screenPaddingH]/[screenPaddingV] (they set the shared page frame and the
+ * bottom-card anchor), [cardGap] and [listGap] (8 dp, the app's baseline step),
+ * and the body type sizes (13/15 sp is already the readable floor — compacting
+ * type to win layout height trades legibility for space).
+ *
+ * Note that Android's official window *height* size classes are too coarse to use
+ * here: compact is < 480 dp and medium is 480-900 dp, so both phones land in the
+ * same bucket despite the 120 dp gap between them. Hence the continuous ramp.
+ */
+@Immutable
+data class SlateRhythm(
+    /** Page side padding. Aligns card edges with the nav bar items. */
+    val screenPaddingH: Dp,
+    /** Page top/bottom padding. Also the last card's gap above the nav bar. */
+    val screenPaddingV: Dp,
+    /** Screen title type size. */
+    val titleSize: TextUnit,
+    /** Title to first card. */
+    val titleGap: Dp,
+    /** Inner padding of a [SlateCard]. */
+    val cardPadding: Dp,
+    /** Gap between sibling cards. */
+    val cardGap: Dp,
+    /** Inner padding of a [SlateItemCard]. */
+    val itemPadding: Dp,
+    /** Gap between rows inside a scrolling list. */
+    val listGap: Dp,
+    /** Label-to-field and field-to-label gaps in a form. */
+    val formGap: Dp,
+    /** Around a [SlateDivider], and description-to-button-row. */
+    val groupGap: Dp,
+    /** Between two tightly coupled lines of text. */
+    val tightGap: Dp,
+    /** Readout row to slider. */
+    val sliderGap: Dp,
+    val sliderHeight: Dp,
+    /** Secondary/supporting text. */
+    val bodySize: TextUnit,
+    /** Primary/emphasised text. */
+    val emphasisSize: TextUnit,
+    /** Labels under a statistic. */
+    val captionSize: TextUnit,
+    /** Large statistic readouts. */
+    val statSize: TextUnit
+) {
+    companion object {
+        /** At or below this content height, everything is fully compacted. */
+        private const val COMPACT_HEIGHT = 700f
+
+        /** At or above this content height, everything is fully relaxed. */
+        private const val RELAXED_HEIGHT = 820f
+
+        fun forHeight(available: Dp): SlateRhythm {
+            val t = ((available.value - COMPACT_HEIGHT) / (RELAXED_HEIGHT - COMPACT_HEIGHT))
+                .coerceIn(0f, 1f)
+            fun flexDp(compact: Float, relaxed: Float): Dp = (compact + (relaxed - compact) * t).dp
+            fun flexSp(compact: Float, relaxed: Float): TextUnit = (compact + (relaxed - compact) * t).sp
+            return SlateRhythm(
+                screenPaddingH = 20.dp,
+                screenPaddingV = 16.dp,
+                // Flexed so the title reads at a consistent *physical* size. A fixed
+                // 32 sp looks noticeably larger on the denser, shorter S23 than on the
+                // 2a; ramping it keeps the two within a couple of percent and buys back
+                // height on exactly the viewport that needs it.
+                titleSize = flexSp(28f, 32f),
+                titleGap = flexDp(12f, 20f),
+                cardPadding = flexDp(10f, 16f),
+                cardGap = 8.dp,
+                itemPadding = flexDp(10f, 12f),
+                listGap = 8.dp,
+                formGap = flexDp(6f, 12f),
+                groupGap = flexDp(10f, 12f),
+                tightGap = flexDp(2f, 6f),
+                sliderGap = flexDp(8f, 12f),
+                // Never below the 48 dp interactive floor once Compose's minimum touch
+                // target is applied around it.
+                sliderHeight = flexDp(24f, 26f),
+                bodySize = 13.sp,
+                emphasisSize = 15.sp,
+                captionSize = 12.sp,
+                statSize = 24.sp
+            )
+        }
+
+        /** Fallback for previews and any subtree without a provider. */
+        val Relaxed: SlateRhythm = forHeight(RELAXED_HEIGHT.dp)
+    }
+}
+
+/**
+ * Provided once for the whole app in `SwiftSlateMainScreen`, from the height the
+ * tab content area actually gets. Read it instead of hardcoding dp so the tabs
+ * stay in agreement.
+ */
+val LocalSlateRhythm = staticCompositionLocalOf { SlateRhythm.Relaxed }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-    id("com.android.application") version "9.3.2" apply false
+    id("com.android.application") version "9.4.0" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.4.10" apply false
 }


### PR DESCRIPTION
Bundles the adaptive-UI work, the Android 12–14 key-loss fix, and both Dependabot bumps so a single merge produces a single release.

Rolls up: closes #141 · supersedes #142 · closes #164 · closes #165

---

## 1. One adaptive vertical rhythm across all tabs

Every tab fits a single viewport with no root scroll and its last card anchored flush above the nav bar, so the cards share a height budget that varies ~120 dp between phones: a Galaxy S23 gives the content area **~697 dp**, a Nothing Phone 2a **~821 dp**. At 14 dp padding the S23 was ~43 dp short and clipped the About card's "Sponsor on GitHub" link, while the 2a had ~81 dp spare that pooled into a single ~104 dp void around the divider.

This adds **`SlateRhythm`**: spacing and type tokens interpolated against the available content height, provided once for the whole app via `LocalSlateRhythm` in `SwiftSlateMainScreen`. `SlateCard`, `SlateItemCard` and `ScreenTitle` read it as their defaults, and all four screens are migrated off literal `dp`/`sp` — so the tabs cannot drift apart.

| token | compact (S23) | relaxed (2a) |
|---|---|---|
| `titleSize` | 28 sp | 32 sp |
| `titleGap` | 12 | 20 |
| `cardPadding` | 10 | 16 |
| `formGap` | 6 | 12 |
| `groupGap` | 10 | 12 |
| `tightGap` | 2 | 6 |
| `sliderGap` | 8 | 12 |
| `itemPadding` | 10 | 12 |

Structural values stay **fixed**: page padding (it sets the shared frame and the bottom-card anchor), the 8 dp card/list step, and body type at 13/15 sp since that is already the readable floor. Buttons stay at 48 dp and text fields at 56 dp, clear of the [48 dp interactive floor](https://developer.android.com/develop/ui/compose/accessibility/api-defaults).

Android's official window *height* size classes are too coarse to drive this — compact is `< 480 dp` and medium is `480–900 dp`, so both phones land in the same bucket despite the 120 dp gap. Hence the continuous ramp.

### Relationship to #163

#163 landed an `isCompact` boolean with a hard 760 dp threshold and inline ternaries, scoped to Settings only. This supersedes that approach for three reasons:

- its card gaps were 6 dp compact / 16 dp relaxed, so inter-card spacing no longer matched the other tabs;
- it left the `Spacer(weight(1f))` pair around the About card's divider, so the ~104 dp void on tall screens was still present;
- being Settings-only, it made Settings diverge from Dashboard/Keys/Commands, which still hardcoded 14 dp padding.

The merge resolution therefore takes the rhythm implementation for `SettingsScreen.kt` and `CommonComponents.kt`. #163 touched only those two files and only their spacing, so nothing else is lost.

### Layout fixes that fall out of this

- **About card** — the two text groups now sit in equally weighted halves, each centring its own group, so the divider lands on the card's midline with symmetric space above the version line and below the sponsor line.
- **Commands** — the gap between the list card and the add-command card was 6.1 dp where every other card gap is 8 dp.
- **Title type** flexes 28–32 sp so it reads at a consistent *physical* size. A fixed 32 sp is 88 px on the denser S23 but 78.8 px on the 2a at the same 1080 px width, a 12% difference. Flexed, it's 77 px vs 78.8 px.

### Verification

Measured from `uiautomator` geometry on both profiles (S23 1080x2340 @440 dpi, Nothing Phone 2a 1080x2412 @394 dpi), re-checked after merging `master`:

| | S23 | 2a |
|---|---|---|
| title height | 32.7 dp | 37.3 dp |
| title → first card | 12.0 | 19.9 |
| card gaps | 8.0 / 8.0 / 8.0 | 8.1 / 8.2 / 8.1 |
| bottom card edge | 730.9 | 859.7 |

Settings cards:

| | Card 1 | Card 2 | Card 3 | Card 4 (About) |
|---|---|---|---|---|
| S23 before | 284.7 | 84.4 | 112.4 | **102.2** (needed 145 → clipped) |
| S23 after | 263.3 | 76.4 | 102.5 | **154.5** (needs 138.6) |
| 2a after | 310.7 | 88.1 | 116.1 | 192.1 |

- **Zero clipping on S23** — "Sponsor on GitHub" went from ending ~10 dp past the card edge to sitting inside it with 15.9 dp of headroom.
- **About divider** sits at y 763.4–763.9 against a 763.65 card midline on the 2a; 22.3 dp above the version line vs 22.5 dp below the sponsor line.
- **Bottom anchor** — the last card ends at the same y on all four tabs.

Dynamic model fetching, `DynamicModelDropdown` and `ProviderModelsCache` are untouched. Gemini and Groq provider paths measure identically.

---

## 2. Android 12–14 silently destroyed stored API keys (#141)

`setUnlockedDeviceRequired(true)` in `KeyCipher.kt` was gated at API 28, which spans Android 9–15 and so includes the three versions Google [documents as broken](https://developer.android.com/reference/android/security/keystore/KeyGenParameterSpec.Builder#setUnlockedDeviceRequired(boolean)). On Android 12, 13 and 14 a key carrying this flag cannot be generated, imported or used unless a secure lock screen is set, and is silently deleted if the user later removes one.

Both failure modes are terminal here:

- **Generation throws**, so `AndroidKeystoreCipher.available` goes false and no API key can ever be saved.
- **Deletion** leaves the stored ciphertext undecryptable, and `getKeys()` maps a null decrypt to `emptyList()`, so keys vanish with no error surfaced.

Reproduced on an Android 14 emulator with no lock screen:

```
E KeyCipher: Keystore init failed
E KeyCipher: java.security.ProviderException: Keystore key generation failed
    at AndroidKeyStoreKeyGeneratorSpi.engineGenerateKey(...)
    at AndroidKeystoreCipher.<init>(KeyCipher.kt:80)
```

Causation isolated rather than assumed: setting a PIN makes init succeed and the "Secure key storage is unavailable" banner disappear; clearing it makes it fail again. After this change the same no-lock-screen device initialises cleanly and the Add Key control is enabled.

The flag is now gated to `VANILLA_ICE_CREAM`, which is Google's stated mitigation. Installs that never managed to generate a key self-heal on next launch, since the alias is created on demand.

Note the regression was introduced by `22ddba5` ("fix: correctness, clipboard and key-storage bugs found in a full audit"), which added the flag at `>= P`; its comment reasons about migration but not about the 12–14 platform bug.

**Supersedes #142**, which proposed the same gate but against `KeyManager.kt`, before the keygen path was extracted into `KeyCipher.kt` — hence its conflict. Original author credited via `Co-authored-by`.

### Two follow-ups deliberately not in scope

1. **Existing installs on 12–14 that already hold a flagged key.** The guard only affects newly generated keys, so a user who has a lock screen keeps the flagged key and remains one settings change away from losing it. Rotating the alias means decrypting, deleting and re-encrypting on the security-critical path, and `KeyInfo` isn't available under Robolectric so it cannot be unit-tested here. Worth its own PR.
2. **The silent-empty-list path deserves a visible error** regardless — unrecoverable key loss currently looks identical to "no keys configured."

---

## 3. Dependency bumps folded in

Merged as their original Dependabot commits, so both PRs auto-close on merge:

- **#165** `com.android.application` 9.3.2 → 9.4.0
- **#164** `softprops/action-gh-release` 3.0.2 → 3.0.3

AGP 9.4.0 validated with a `clean testDebugUnitTest assembleDebug` from scratch, not an incremental build.

---

## Testing

- `./gradlew.bat clean testDebugUnitTest assembleDebug` — **BUILD SUCCESSFUL**, **182/182 tests pass** on AGP 9.4.0.
- Layout geometry re-measured on both device profiles after merging `master`.
- Keys fix verified on an Android 14 emulator in the exact configuration that previously threw.
