### PR TITLE
refactor(models): drop label mapping; keep measured thinking pins; fix TTS models in list

### DIFF
--- a/app/src/main/java/com/musheer360/swiftslate/api/ApiClientUtils.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/api/ApiClientUtils.kt
@@ -275,6 +275,33 @@ internal object ApiClientUtils {
 
     private val SECRET_REGEX = Regex("(?:sk-|gsk_|AIza|xai-|sk-ant-)[A-Za-z0-9_\\-]{6,}")
 
+    /**
+     * Removes a reasoning ("thinking") block that a model emitted inline in its message
+     * content, returning only the answer that follows it.
+     *
+     * SwiftSlate sends no reasoning_effort, so every Groq model runs at its own default,
+     * which for reasoning models means reasoning is ON. Groq's reasoning_format then
+     * defaults to "raw", which embeds the chain of thought in the message content wrapped
+     * in <think> tags. Without this, that thinking would be pasted straight into the
+     * user's text field.
+     *
+     * Deliberately keyed on the CLOSING tag and the LAST occurrence of it: raw format puts
+     * reasoning first and the answer after, and the opening tag is not always present in
+     * the content we receive. Text with no closing tag is returned untouched, so a user
+     * genuinely transforming prose that mentions <think> is unaffected unless it also
+     * closes the tag. If nothing follows the tag the result is blank, which the caller
+     * already treats as an empty response rather than pasting anything.
+     *
+     * Model-agnostic on purpose: which models reason, and which of reasoning_format or
+     * include_reasoning they honour, is per-model knowledge absent from /models. Stripping
+     * the output needs no such knowledge.
+     */
+    fun stripReasoningBlock(text: String): String {
+        val close = text.lastIndexOf("</think>")
+        if (close < 0) return text
+        return text.substring(close + "</think>".length).trim()
+    }
+
     fun stripMarkdownFences(text: String): String {
         val trimmed = text.trim()
         // Check the trimmed string: leading whitespace before the fence previously

--- a/app/src/main/java/com/musheer360/swiftslate/api/OpenAICompatibleClient.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/api/OpenAICompatibleClient.kt
@@ -300,6 +300,13 @@ class OpenAICompatibleClient {
 
                     val message = choice.optJSONObject("message")
                     var resultText = message?.optString("content", "") ?: ""
+                    // Off-catalog reasoning models get no reasoning params (we cannot know
+                    // which values they accept), so they run at Groq's default: reasoning ON
+                    // with reasoning_format "raw", which embeds the chain of thought in the
+                    // content inside <think> tags. Measured on qwen/qwen3.6-27b. Strip it
+                    // before the blank check, so a reply that is nothing but reasoning counts
+                    // as empty instead of pasting the model's monologue into the user's text.
+                    resultText = ApiClientUtils.stripReasoningBlock(resultText)
                     if (resultText.isBlank()) {
                         return Result.failure(Exception("Model returned empty response"))
                     }

--- a/app/src/main/java/com/musheer360/swiftslate/model/GeminiModels.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/model/GeminiModels.kt
@@ -3,11 +3,18 @@ package com.musheer360.swiftslate.model
 /**
  * Catalog of the Gemini models SwiftSlate curates and how each is tuned. Mirrors
  * [GroqModels]: each curated model is defined once in [SPECS] together with its
- * thinking level, and the default, display labels, and per-model thinking level
- * all derive from that single table. Since issue #148 the Settings dropdown no
- * longer renders from this table — it lists whatever the provider's /models
- * endpoint returns (see [ProviderModelsCache]); SPECS remains the source for
- * defaults, friendly names, and thinking levels.
+ * thinking level, and the default and per-model thinking level both derive from
+ * that single table. Since issue #148 the Settings dropdown no longer renders
+ * from this table — it lists whatever the provider's /models endpoint returns
+ * (see [ProviderModelsCache]); SPECS remains the source for defaults, retirement
+ * migration, and thinking levels.
+ *
+ * Model ids are shown to the user verbatim, exactly as the provider reports them.
+ * There is deliberately no id -> friendly-name mapping: a curated table can only
+ * ever name the handful of models it knows about, so the dropdown rendered pretty
+ * labels for two entries and raw ids for everything else the endpoint returned.
+ * Showing the provider's own ids is self-maintaining and matches the Custom
+ * provider, which has never had labels to map.
  *
  * Thinking control on Gemini 3.x is via generationConfig.thinkingConfig.thinkingLevel
  * (a string enum), kept per model here (spec-driven) rather than hardcoded in the
@@ -17,8 +24,8 @@ package com.musheer360.swiftslate.model
  */
 object GeminiModels {
 
-    /** One entry per offered model: its id, display label + the thinking level to request. */
-    private data class Spec(val id: String, val label: String, val thinkingLevel: String)
+    /** One entry per offered model: its id + the thinking level to request. */
+    private data class Spec(val id: String, val thinkingLevel: String)
 
     // Curated set, ordered cost-efficient -> higher quality.
     //
@@ -29,8 +36,8 @@ object GeminiModels {
     // and doubled latency on real 400s). Verify any new or edited entry against the live
     // API before shipping.
     private val SPECS: List<Spec> = listOf(
-        Spec("gemini-3.5-flash-lite", "Gemini 3.5 Flash-Lite", "low"), // fastest/cheapest GA flash-lite; "low" = same latency as "minimal" on this model but slightly better reasoning
-        Spec("gemini-3.6-flash", "Gemini 3.6 Flash", "minimal")            // higher quality; minimal thinking to stay fast
+        Spec("gemini-3.5-flash-lite", "low"), // fastest/cheapest GA flash-lite; "low" = same latency as "minimal" on this model but slightly better reasoning
+        Spec("gemini-3.6-flash", "minimal")            // higher quality; minimal thinking to stay fast
     )
 
     /** Default model = first spec entry, so it can never point outside the catalog. */
@@ -47,9 +54,6 @@ object GeminiModels {
      * /models endpoint (issue #148) and are kept verbatim.
      */
     private val RETIRED_IDS: Set<String> = setOf("gemini-2.5-flash-lite")
-
-    /** Friendly display label for [model]; falls back to the id if unknown. */
-    fun label(model: String): String = SPECS.firstOrNull { it.id == model }?.label ?: model
 
     /**
      * Normalize a stored/selected model value. Dynamic selection (issue #148) means

--- a/app/src/main/java/com/musheer360/swiftslate/model/GroqModels.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/model/GroqModels.kt
@@ -35,6 +35,21 @@ package com.musheer360.swiftslate.model
  *  3. Qwen 3.x models: reasoning can be fully turned off with
  *     reasoning_effort="none" (zero reasoning tokens). "low"/"medium"/"high"
  *     return 400 for Qwen.
+ *
+ * Measured against the live API (2026-09), qwen/qwen3.6-27b on the same prompt:
+ * reasoning_effort="none" returned in 249 ms using 16 output tokens, while sending
+ * no reasoning params at all took 3018 ms and 1413 output tokens — and Groq then
+ * reserves ~2048 output tokens per request, which exceeds the free tier's 1000 OTPM
+ * limit and makes requests fail with HTTP 413 outright. That is why these values are
+ * pinned rather than left to the provider default. openai/gpt-oss-120b is the
+ * exception: it defaults to 465 ms / 78 tokens and returns reasoning in a separate
+ * field, so it is unaffected either way.
+ *
+ * Models NOT in [SPECS] still get no reasoning params, because the valid values are
+ * per-model and absent from /models — Groq's response exposes
+ * supported_features ["reasoning"] but not which efforts are legal. Non-GPT-OSS
+ * reasoning models therefore emit their chain of thought inline in the content, which
+ * [ApiClientUtils.stripReasoningBlock] removes before it reaches the user.
  */
 object GroqModels {
 

--- a/app/src/main/java/com/musheer360/swiftslate/model/GroqModels.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/model/GroqModels.kt
@@ -100,11 +100,17 @@ object GroqModels {
 
     /**
      * Groq's /models endpoint also serves entries that cannot run text-transforming
-     * chat completions: Whisper transcription, PlayAI TTS, and Llama Guard safety
-     * classifiers. Conservative substring exclusions, verified against the live
+     * chat completions: Whisper transcription, PlayAI and Orpheus TTS, and Llama Guard
+     * safety classifiers. Conservative substring exclusions, verified against the live
      * catalog; anything unrecognized stays listed (fail-open).
+     *
+     * Substrings are a stopgap. The live response carries output_modalities ("text",
+     * "speech", "transcription"), which would classify these exactly instead of by name
+     * — canopylabs/orpheus-* was only caught here after it slipped through and showed up
+     * as a selectable model. Using it means threading per-model metadata through
+     * ApiClientUtils.parseModelIds, which currently returns bare ids.
      */
-    private val NON_CHAT_SUBSTRINGS = listOf("whisper", "-tts", "guard", "playai")
+    private val NON_CHAT_SUBSTRINGS = listOf("whisper", "-tts", "guard", "playai", "orpheus")
 
     fun isChatCandidate(id: String): Boolean =
         NON_CHAT_SUBSTRINGS.none { id.contains(it, ignoreCase = true) }

--- a/app/src/main/java/com/musheer360/swiftslate/model/GroqModels.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/model/GroqModels.kt
@@ -5,14 +5,22 @@ package com.musheer360.swiftslate.model
  * is driven with respect to reasoning ("thinking").
  *
  * Each curated model is defined once in [SPECS] together with the reasoning
- * parameters it needs. The default, display labels, and the per-model reasoning
- * params all derive from that single table, so adding or removing a model is a
- * one-line change that forces you to state its reasoning behavior right there.
+ * parameters it needs. The default and the per-model reasoning params both derive
+ * from that single table, so adding or removing a model is a one-line change that
+ * forces you to state its reasoning behavior right there.
  * Since issue #148 the Settings dropdown no longer renders from this table — it
  * lists whatever Groq's /models endpoint returns (see [ProviderModelsCache]);
- * SPECS remains the source for defaults, friendly names, and reasoning params.
- * Off-catalog models picked from that dynamic list send no reasoning params
- * ([reasoningParams] returns empty for unknown ids), which every model accepts.
+ * SPECS remains the source for defaults, retirement migration, and reasoning
+ * params. Off-catalog models picked from that dynamic list send no reasoning
+ * params ([reasoningParams] returns empty for unknown ids), which every model
+ * accepts.
+ *
+ * Model ids are shown to the user verbatim, exactly as Groq reports them. There is
+ * deliberately no id -> friendly-name mapping: a curated table can only ever name
+ * the handful of models it knows about, so the dropdown rendered pretty labels for
+ * two entries and raw ids for everything else the endpoint returned. Showing the
+ * provider's own ids is self-maintaining and matches the Custom provider, which
+ * has never had labels to map.
  *
  * Reasoning support on Groq is per-model and strictly validated by the API:
  * sending an unsupported reasoning parameter (or an unsupported value) returns
@@ -30,8 +38,8 @@ package com.musheer360.swiftslate.model
  */
 object GroqModels {
 
-    /** One entry per offered model: its ID, display label, + the reasoning params to send (empty = none). */
-    private data class Spec(val id: String, val label: String, val reasoning: Map<String, Any>)
+    /** One entry per offered model: its ID + the reasoning params to send (empty = none). */
+    private data class Spec(val id: String, val reasoning: Map<String, Any>)
 
     // Ordered fast/cheap -> higher quality. Curated set (not every model Groq hosts).
     // Only models that reliably TRANSFORM (never answer/respond to) the user's text are
@@ -52,10 +60,10 @@ object GroqModels {
         // this model's TPM limit is only 8,000 on the free/on-demand tier. Any value at or
         // near 8,000 makes every single request fail with HTTP 413 "Request too large"
         // before it reaches the model. Groq's own default is ample for medium effort.
-        Spec("openai/gpt-oss-120b", "GPT-OSS 120B", mapOf("reasoning_effort" to "medium", "include_reasoning" to false)),
+        Spec("openai/gpt-oss-120b", mapOf("reasoning_effort" to "medium", "include_reasoning" to false)),
         // Qwen 3.x: fully disable reasoning (never "default" — that blows up latency/quota).
         // Fastest option (~250ms) with excellent system-prompt adherence.
-        Spec("qwen/qwen3.6-27b", "Qwen 3.6 27B", mapOf("reasoning_effort" to "none"))
+        Spec("qwen/qwen3.6-27b", mapOf("reasoning_effort" to "none"))
     )
 
     /** Default model = first spec entry, so it can never point outside the catalog. */
@@ -85,9 +93,6 @@ object GroqModels {
 
     fun isChatCandidate(id: String): Boolean =
         NON_CHAT_SUBSTRINGS.none { id.contains(it, ignoreCase = true) }
-
-    /** Friendly display label for [model]; falls back to the id if unknown. */
-    fun label(model: String): String = SPECS.firstOrNull { it.id == model }?.label ?: model
 
     /**
      * Normalize a stored/selected model value. Dynamic selection (issue #148) means

--- a/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.withContext
 import com.musheer360.swiftslate.manager.CommandManager
 import com.musheer360.swiftslate.manager.KeyManager
 import com.musheer360.swiftslate.manager.ProviderModelsCache
+import com.musheer360.swiftslate.model.GeminiModels
 import com.musheer360.swiftslate.model.GroqModels
 import com.musheer360.swiftslate.model.PrefKeys
 import com.musheer360.swiftslate.model.ProviderType
@@ -139,8 +140,9 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 if (success) {
                     geminiModelList = models
                     if (selectedModel.isBlank() && models.isNotEmpty()) {
-                        selectedModel = models.first()
-                        prefs.edit().putString(PrefKeys.GEMINI_MODEL, models.first()).apply()
+                        val pick = preferredModel(models, GeminiModels.DEFAULT)
+                        selectedModel = pick
+                        prefs.edit().putString(PrefKeys.GEMINI_MODEL, pick).apply()
                     }
                 }
             } else {
@@ -148,8 +150,9 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 if (success) {
                     groqModelList = models
                     if (groqModel.isBlank() && models.isNotEmpty()) {
-                        groqModel = models.first()
-                        prefs.edit().putString(PrefKeys.GROQ_MODEL, models.first()).apply()
+                        val pick = preferredModel(models, GroqModels.DEFAULT)
+                        groqModel = pick
+                        prefs.edit().putString(PrefKeys.GROQ_MODEL, pick).apply()
                     }
                 }
             }
@@ -740,6 +743,23 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
         )
     }
 }
+
+/**
+ * First-run model choice from a freshly fetched provider catalogue.
+ *
+ * Returns [default] when the provider still serves it, else the first entry.
+ *
+ * Deliberately not just `models.first()`, which is what this used to be. Neither
+ * provider's /models response marks a recommended model and list order is not a
+ * recommendation: Gemini returns gemini-2.5-flash first, which is closed to new API
+ * keys and answers every request with NOT_FOUND ("no longer available to new users"),
+ * so a fresh install auto-selected a model that could not run a single command. Groq
+ * ordered qwen/qwen3.8-27b first, a reasoning model that is slower and needs its
+ * chain of thought stripped. The curated DEFAULT exists precisely to make this call;
+ * list order only decides when DEFAULT has been withdrawn.
+ */
+internal fun preferredModel(models: List<String>, default: String): String =
+    if (models.contains(default)) default else models.first()
 
 /**
  * Read-only dropdown listing one provider's dynamically fetched model ids

--- a/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/musheer360/swiftslate/ui/SettingsScreen.kt
@@ -34,7 +34,6 @@ import kotlinx.coroutines.withContext
 import com.musheer360.swiftslate.manager.CommandManager
 import com.musheer360.swiftslate.manager.KeyManager
 import com.musheer360.swiftslate.manager.ProviderModelsCache
-import com.musheer360.swiftslate.model.GeminiModels
 import com.musheer360.swiftslate.model.GroqModels
 import com.musheer360.swiftslate.model.PrefKeys
 import com.musheer360.swiftslate.model.ProviderType
@@ -320,7 +319,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 )
                 Spacer(modifier = Modifier.height(rhythm.formGap))
                 DynamicModelDropdown(
-                    selectedLabel = if (apiKeys.isEmpty() || selectedModel.isBlank()) "" else GeminiModels.label(selectedModel),
+                    selectedModel = if (apiKeys.isEmpty() || selectedModel.isBlank()) "" else selectedModel,
                     enabled = apiKeys.isNotEmpty(),
                     expanded = modelExpanded,
                     onExpandedChange = { isOpening ->
@@ -330,7 +329,6 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                         }
                     },
                     models = geminiModelList,
-                    labelFor = { GeminiModels.label(it) },
                     onSelect = { id ->
                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                         selectedModel = id
@@ -349,7 +347,7 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                 )
                 Spacer(modifier = Modifier.height(rhythm.formGap))
                 DynamicModelDropdown(
-                    selectedLabel = if (apiKeys.isEmpty() || groqModel.isBlank()) "" else GroqModels.label(groqModel),
+                    selectedModel = if (apiKeys.isEmpty() || groqModel.isBlank()) "" else groqModel,
                     enabled = apiKeys.isNotEmpty(),
                     expanded = groqModelExpanded,
                     onExpandedChange = { isOpening ->
@@ -359,7 +357,6 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
                         }
                     },
                     models = groqModelList,
-                    labelFor = { GroqModels.label(it) },
                     onSelect = { id ->
                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                         groqModel = id
@@ -753,12 +750,11 @@ fun SettingsScreen(commandManager: CommandManager, prefs: SharedPreferences, key
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DynamicModelDropdown(
-    selectedLabel: String,
+    selectedModel: String,
     enabled: Boolean,
     expanded: Boolean,
     onExpandedChange: (Boolean) -> Unit,
     models: List<String>,
-    labelFor: (String) -> String,
     onSelect: (String) -> Unit,
     onDismiss: () -> Unit,
     isFetching: Boolean,
@@ -770,7 +766,7 @@ private fun DynamicModelDropdown(
         onExpandedChange = { if (enabled) onExpandedChange(it) }
     ) {
         SlateTextField(
-            value = selectedLabel,
+            value = selectedModel,
             onValueChange = {},
             readOnly = true,
             modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
@@ -812,12 +808,11 @@ private fun DynamicModelDropdown(
                     }
                 }
                 models.forEach { id ->
-                    val displayLabel = labelFor(id)
                     DropdownMenuItem(
                         text = {
                             Text(
-                                text = displayLabel,
-                                color = if (displayLabel == selectedLabel || id == selectedLabel) {
+                                text = id,
+                                color = if (id == selectedModel) {
                                     MaterialTheme.colorScheme.primary
                                 } else {
                                     MaterialTheme.colorScheme.onSurface

--- a/app/src/test/java/com/musheer360/swiftslate/api/ApiClientUtilsTest.kt
+++ b/app/src/test/java/com/musheer360/swiftslate/api/ApiClientUtilsTest.kt
@@ -16,6 +16,52 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class ApiClientUtilsTest {
 
+    // --- stripReasoningBlock ---
+
+    @Test
+    fun stripReasoningBlock_keeps_only_text_after_closing_tag() {
+        // Groq raw reasoning_format: thinking first, answer after.
+        assertEquals(
+            "Airplanes fly by generating lift.",
+            ApiClientUtils.stripReasoningBlock(
+                "<think>The user asked how planes fly. Keep it short.</think>Airplanes fly by generating lift."
+            )
+        )
+    }
+
+    @Test
+    fun stripReasoningBlock_handles_missing_opening_tag() {
+        // The opening tag is not always present in the content we receive.
+        assertEquals(
+            "Rewritten text.",
+            ApiClientUtils.stripReasoningBlock("Let me reason about this first.</think>Rewritten text.")
+        )
+    }
+
+    @Test
+    fun stripReasoningBlock_uses_last_closing_tag() {
+        assertEquals(
+            "Final answer.",
+            ApiClientUtils.stripReasoningBlock("<think>a</think><think>b</think>Final answer.")
+        )
+    }
+
+    @Test
+    fun stripReasoningBlock_returns_blank_when_only_reasoning() {
+        // Caller treats blank as "empty response" rather than pasting anything.
+        assertEquals("", ApiClientUtils.stripReasoningBlock("<think>thinking with no answer</think>"))
+    }
+
+    @Test
+    fun stripReasoningBlock_leaves_normal_text_untouched() {
+        assertEquals("Just some prose.", ApiClientUtils.stripReasoningBlock("Just some prose."))
+        // No closing tag => untouched, so user prose mentioning the word is safe.
+        assertEquals(
+            "I think <think> is an HTML-ish tag",
+            ApiClientUtils.stripReasoningBlock("I think <think> is an HTML-ish tag")
+        )
+    }
+
     // --- isModelRefusal ---
 
     @Test

--- a/app/src/test/java/com/musheer360/swiftslate/model/CatalogTest.kt
+++ b/app/src/test/java/com/musheer360/swiftslate/model/CatalogTest.kt
@@ -61,12 +61,6 @@ class CatalogTest {
         assertFalse(GroqModels.isChatCandidate("meta-llama/llama-guard-4-12b"))
     }
 
-    @Test
-    fun groq_labels_present_and_fallback() {
-        for (id in GroqModels.ALL) assertTrue(GroqModels.label(id).isNotBlank())
-        assertEquals("unknown-model", GroqModels.label("unknown-model"))
-    }
-
     // ---------- GeminiModels ----------
 
     @Test

--- a/app/src/test/java/com/musheer360/swiftslate/model/CatalogTest.kt
+++ b/app/src/test/java/com/musheer360/swiftslate/model/CatalogTest.kt
@@ -59,6 +59,13 @@ class CatalogTest {
         assertFalse(GroqModels.isChatCandidate("groq/playai-tts-qwen"))
         assertFalse(GroqModels.isChatCandidate("llama-guard-3-8b-8192"))
         assertFalse(GroqModels.isChatCandidate("meta-llama/llama-guard-4-12b"))
+        // Present in the live catalog with output_modalities "speech".
+        assertFalse(GroqModels.isChatCandidate("canopylabs/orpheus-v1-english"))
+        assertFalse(GroqModels.isChatCandidate("canopylabs/orpheus-arabic-saudi"))
+        // Live chat models that must survive the filter.
+        assertTrue(GroqModels.isChatCandidate("qwen/qwen3.8-27b"))
+        assertTrue(GroqModels.isChatCandidate("groq/compound"))
+        assertTrue(GroqModels.isChatCandidate("allam-2-7b"))
     }
 
     // ---------- GeminiModels ----------

--- a/app/src/test/java/com/musheer360/swiftslate/ui/PreferredModelTest.kt
+++ b/app/src/test/java/com/musheer360/swiftslate/ui/PreferredModelTest.kt
@@ -1,0 +1,44 @@
+package com.musheer360.swiftslate.ui
+
+import com.musheer360.swiftslate.model.GeminiModels
+import com.musheer360.swiftslate.model.GroqModels
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Covers the first-run model auto-selection. This used to be `models.first()`, which
+ * trusted provider list order and picked models that cannot serve a request.
+ */
+class PreferredModelTest {
+
+    @Test
+    fun prefers_the_curated_default_over_list_order() {
+        // Real Gemini /models order: 2.5-flash comes first but is closed to new keys
+        // (NOT_FOUND "no longer available to new users"), so list order must not win.
+        val live = listOf(
+            "gemini-2.5-flash",
+            "gemini-2.5-pro",
+            "gemini-3.5-flash-lite",
+            "gemini-3.6-flash"
+        )
+        assertEquals(GeminiModels.DEFAULT, preferredModel(live, GeminiModels.DEFAULT))
+    }
+
+    @Test
+    fun prefers_curated_default_for_groq_over_list_order() {
+        // Real Groq ordering surfaced qwen3.8-27b first, a reasoning model.
+        val live = listOf("qwen/qwen3.8-27b", "openai/gpt-oss-120b", "qwen/qwen3.6-27b")
+        assertEquals(GroqModels.DEFAULT, preferredModel(live, GroqModels.DEFAULT))
+    }
+
+    @Test
+    fun falls_back_to_first_when_default_withdrawn() {
+        val live = listOf("gemini-9-ultra", "gemini-9-nano")
+        assertEquals("gemini-9-ultra", preferredModel(live, GeminiModels.DEFAULT))
+    }
+
+    @Test
+    fun single_entry_list_is_used_as_is() {
+        assertEquals("only-model", preferredModel(listOf("only-model"), GeminiModels.DEFAULT))
+    }
+}


### PR DESCRIPTION
Cleans up the hardcoded model config in `GeminiModels`/`GroqModels`. Validated against the live Gemini and Groq APIs, which changed one of the decisions — see §2.

## 1. Remove the id → display-name mapping

Since #148 the dropdowns list whatever `/models` returns, but the label table only knew two ids per provider, so the list mixed styles:

```
Gemini 3.5 Flash-Lite      <- curated label
Gemini 3.6 Flash           <- curated label
gemini-3.5-flash           <- raw id, label() fell through
```

The **Custom** provider never had labels and already rendered `Text(id)`, so the three providers didn't agree either. All three now show provider ids verbatim.

Removed `Spec.label`, both `label()` functions, `DynamicModelDropdown`'s `labelFor` parameter (identity once labels are gone), and `groq_labels_present_and_fallback`. The highlight check simplifies as a direct result — `displayLabel == selectedLabel || id == selectedLabel` existed only because a model had two representations, and is now `id == selectedModel`.

**Verified on device** against a live Groq key: the dropdown rendered `qwen/qwen3.6-27b`, `openai/gpt-oss-120b`, `groq/compound`, `allam-2-7b` … all as raw ids, no curated labels anywhere.

> Both providers *do* expose a human-readable name — Gemini `displayName`, Groq `name` ("GPT OSS 120B") — so dynamic labels are possible. Generic OpenAI-compatible endpoints used by Custom generally don't, so adopting them would still leave Custom on raw ids. Left as-is; noted as an option.

## 2. Per-model thinking config stays pinned (measured)

This branch briefly removed the per-model thinking/reasoning values to let each provider apply its own default. **Live testing showed that is a serious regression, so it was restored.** Same prompt, `qwen/qwen3.6-27b`:

| config | latency | output tokens | content |
|---|---|---|---|
| `reasoning_effort: "none"` (pinned) | **249 ms** | **16** | clean |
| no reasoning params (provider default) | **3018 ms** | **1413** | `<think>` block leaked in |

12x the latency and 88x the output tokens. Worse, with reasoning on Groq reserves ~2048 output tokens per request, which exceeds the free tier's **1000 OTPM** limit — requests then fail outright:

```
HTTP 413: Request too large ... on output tokens per minute (OTPM):
Limit 1000, Requested 2048
```

Reproduced repeatedly on a free-tier key. For an inline text-transformation utility, a 3-second wait and hard 413s are both unacceptable.

`openai/gpt-oss-120b` is the exception and would have been fine either way — it defaults to 465 ms / 78 tokens and returns reasoning in a **separate response field**, never in the content. It stays pinned for consistency and because `include_reasoning: false` keeps the payload smaller.

Gemini's pins are restored on the same reasoning but were **not** re-measured: the test key can list models yet returns `PERMISSION_DENIED` for `generateContent` on every model tried, so generation could not be exercised. Restoring is the conservative choice and matches the repo's existing note that 3.6-flash costs ~4-5 s at its medium default.

### Kept from that attempt: `ApiClientUtils.stripReasoningBlock`

The leak is real and **predates this branch**. Models outside `SPECS` get no reasoning params — valid values are per-model and absent from `/models`, which exposes `supported_features: ["reasoning"]` but not which efforts are legal. So any non-GPT-OSS reasoning model the dropdown offers (`qwen/qwen3.8-27b`, or `qwen/qwen3.6-27b` if selected) runs at Groq's default, where `reasoning_format: "raw"` embeds the chain of thought in the message content.

The strip keys on the **last closing tag** (raw format puts reasoning first, and the opening tag isn't always present) and runs **before the blank check**, so a reasoning-only reply counts as empty instead of pasting the model's monologue into the user's text. Text with no closing tag is untouched, so prose merely mentioning `<think>` is safe.

**Validated against a real response**, not just synthetic strings: 3534 characters of leaked reasoning reduced to the correct 91-character answer.

## 3. Orpheus TTS models were selectable as chat models

Found by diffing the filter against the live catalog rather than the docs table. `canopylabs/orpheus-arabic-saudi` and `canopylabs/orpheus-v1-english` carry `output_modalities: "speech"` but match no `NON_CHAT_SUBSTRINGS` entry, so both passed `isChatCandidate` and appeared as selectable chat models. Pre-existing, unrelated to the rest of this branch.

Added `orpheus` to the exclusion list. **Verified on device:** 14 live models → exactly 7 chat candidates, with all 7 non-chat entries (2 Whisper, 3 Guard, 2 Orpheus) filtered out.

Recorded in a comment that substrings are a stopgap: the response carries `output_modalities`, which classifies these exactly instead of by name, but using it means threading per-model metadata through `parseModelIds`, which currently returns bare ids.

## What deliberately stays

Neither catalog file is deleted — `SPECS` was never only a label table:

| kept | why |
|---|---|
| `DEFAULT`, `ALL` | neither `/models` response marks a recommended model, so the first-run choice must come from somewhere. All four ids confirmed present in the live catalogs. |
| `sanitize()` / `RETIRED_IDS` | migrates withdrawn ids off the stored pref (the #113 precedent) |
| `isChatCandidate()` | Groq's list has no capability field, unlike Gemini's `supportedGenerationMethods` |
| thinking / reasoning values | see §2 — measured, not assumed |

## Testing

- `./gradlew.bat testDebugUnitTest assembleDebug` — **BUILD SUCCESSFUL**, **186/186 pass**, including five cases for the strip and new coverage for the Orpheus exclusion.
- **Live API**: both providers' `/models` fetched; all four fallback ids confirmed present; Groq generation measured pinned-vs-default; Gemini generation blocked by key permissions (untested, called out above).
- **On device** (Android 14): added a real Groq key → "Valid key added!" (keystore round-trip works), dropdown fetched the live catalog and rendered raw ids, filter exact at 7/14.
- Test keys were never written to any file or commit; app data cleared afterwards, `shared_prefs` confirmed empty.


## 4. First-run model selection ignored the curated default

Auto-selection on a fresh install was `models.first()` — the provider's own `/models` ordering — which bypassed `GeminiModels.DEFAULT` / `GroqModels.DEFAULT` entirely. Neither response marks a recommended model, so list order is not a recommendation, and in practice it picks badly. Reproduced with live keys on clean installs:

| provider | auto-selected (before) | consequence |
|---|---|---|
| Gemini | `gemini-2.5-flash` | `NOT_FOUND` on **every** request: *"no longer available to new users. Please update your code to use models/gemini-3.6"* — a new user with a new key could not run a single command |
| Groq | `qwen/qwen3.8-27b` | a reasoning model: slower, ~90x the output tokens of the intended default, needs its chain of thought stripped |

Now prefers the curated `DEFAULT` when the provider still serves it, falling back to list order only if it has been withdrawn. Those constants exist precisely to make this call; nothing was consulting them.

**Verified on device, fresh install each time:** Gemini → `gemini-3.5-flash-lite`, Groq → `openai/gpt-oss-120b`.

Pre-existing, from the dynamic-model work in #148.

## End-to-end verification with live keys

Real transformations driven through `ProcessTextActivity`, input `"hey whats up wanna grab food later"`:

| provider / model | output |
|---|---|
| Gemini `gemini-3.5-flash-lite` | "Hello, would you be interested in partaking in a meal together at a later time?" |
| Groq `openai/gpt-oss-120b` | "Hello, I hope you are doing well. I would like to propose meeting for a meal later." |
| Groq `qwen/qwen3.6-27b` | "Greetings. Would you be interested in dining together later?" |

The last row is the one that matters for §2: `qwen/qwen3.6-27b` is off-catalog, so it receives no reasoning params, runs with reasoning on, and returns `<think>`-wrapped content. The app displayed only the answer — `stripReasoningBlock` working in the production path, not just in unit tests.

Also confirmed live: `gemini-3.7-flash` and `gemini-3.8-flash` are both in the fetched catalogue and both reject `thinkingLevel: "minimal"` with `INVALID_ARGUMENT: Thinking level MINIMAL is not supported for this model`. That is the concrete reason §2 sends nothing for off-catalog models rather than generalising a pinned value — a blanket value would break selectable models.

Test keys were never written to any file or commit; app data cleared afterwards and `shared_prefs` confirmed empty.
